### PR TITLE
feat: capability-aware greeting for first-run DM

### DIFF
--- a/src/ollim_bot/bot.py
+++ b/src/ollim_bot/bot.py
@@ -301,7 +301,11 @@ def create_bot() -> commands.Bot:
         if resumed:
             await dm.send("hey, i'm back. picking up where we left off.")
         else:
-            await dm.send(f"hey {USER_NAME.lower()}, {BOT_NAME} is online. what's on your plate today?")
+            await dm.send(
+                f"hey {USER_NAME.lower()}, {BOT_NAME} is online. i can set up morning check-ins, "
+                "manage your tasks and calendar, and remind you about things before they slip. "
+                "what's on your plate today?"
+            )
 
     @bot.event
     async def on_message(message: discord.Message):


### PR DESCRIPTION
## Summary
- When the bot starts without a prior session (first run), the DM greeting now mentions the three core value props: morning check-ins, task/calendar management, and reminders.
- The resume greeting ("hey, i'm back. picking up where we left off.") stays unchanged.
- One sentence longer but immediately tells the user what to try.

## Test plan
- [x] `uv run pytest` — all 515 tests pass
- [x] Pre-commit hooks (ruff lint, ruff format, ty) pass
- [ ] Manual: start the bot without a prior session file and verify the new greeting appears in DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)