### PR TITLE
fix: replace assert with proper error in Google OAuth

### DIFF
--- a/src/ollim_bot/google/auth.py
+++ b/src/ollim_bot/google/auth.py
@@ -4,6 +4,8 @@ Add new scopes to SCOPES when integrating additional Google services.
 After adding scopes, delete ~/.ollim-bot/state/token.json to re-consent.
 """
 
+import sys
+
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -36,10 +38,13 @@ def get_credentials() -> Credentials:
         TOKEN_FILE.write_text(creds.to_json())
         return creds
 
-    assert CREDENTIALS_FILE.exists(), (
-        f"Missing {CREDENTIALS_FILE} -- download OAuth client credentials "
-        "from Google Cloud Console and save at that path"
-    )
+    if not CREDENTIALS_FILE.exists():
+        print(f"Google credentials not found at {CREDENTIALS_FILE}", file=sys.stderr)
+        print("To set up Google integration:", file=sys.stderr)
+        print("  1. Go to https://console.cloud.google.com/", file=sys.stderr)
+        print("  2. Create OAuth credentials (Desktop application type)", file=sys.stderr)
+        print(f"  3. Save the JSON file to {CREDENTIALS_FILE}", file=sys.stderr)
+        raise SystemExit(1)
     flow = InstalledAppFlow.from_client_secrets_file(str(CREDENTIALS_FILE), SCOPES)
     creds = flow.run_local_server(port=0, bind_addr="127.0.0.1")
     STATE_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Replace `assert CREDENTIALS_FILE.exists()` in `google/auth.py` with an explicit `if not ... exists()` check
- Prints actionable setup instructions (Google Cloud Console URL, steps) to stderr instead of an opaque `AssertionError` traceback
- Raises `SystemExit(1)` for a clean exit -- the assert was silently stripped by Python's `-O` flag

## Test plan
- [x] All 515 existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (ruff lint, ruff format, ty)
- [ ] Manual: verify error output by running a Google command without the OAuth credential file present

Generated with Claude Code