### PR TITLE
fix: catch Discord startup failures with specific error messages

### DIFF
--- a/src/ollim_bot/main.py
+++ b/src/ollim_bot/main.py
@@ -14,6 +14,7 @@ import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import discord
 from dotenv import load_dotenv
 
 if TYPE_CHECKING:
@@ -171,6 +172,14 @@ async def _run(bot: Bot, token: str) -> None:
         await bot.start(token)
     except asyncio.CancelledError:
         pass  # Signal handler already notified and closed
+    except discord.LoginFailure:
+        print("Invalid Discord token. Check DISCORD_TOKEN in .env", file=sys.stderr)
+        print("Get a new token: Discord Developer Portal > Bot > Reset Token", file=sys.stderr)
+        raise SystemExit(1) from None
+    except discord.PrivilegedIntentsRequired:
+        print("Message Content Intent is not enabled.", file=sys.stderr)
+        print("Enable it: Discord Developer Portal > Bot > Privileged Gateway Intents", file=sys.stderr)
+        raise SystemExit(1) from None
     except Exception as e:
         await _notify_exit(bot, f"{type(e).__name__}: {e}")
         raise


### PR DESCRIPTION
## Summary
- Add specific exception handlers for `discord.LoginFailure` and `discord.PrivilegedIntentsRequired` in `_run()` before the generic `Exception` catch
- Prints actionable error messages to stderr (what's wrong + how to fix it) instead of showing a confusing traceback
- Exits cleanly with `SystemExit(1)` so no traceback noise for known configuration errors

## Test plan
- [x] `uv run pytest` -- all 515 tests pass
- [x] Pre-commit hooks (ruff lint, ruff format, ty) pass
- [ ] Manual: start bot with invalid `DISCORD_TOKEN` -- should print helpful message and exit
- [ ] Manual: start bot without Message Content Intent enabled -- should print helpful message and exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)