### PR TITLE
fix: consolidate env var validation with example values

### DIFF
--- a/src/ollim_bot/main.py
+++ b/src/ollim_bot/main.py
@@ -218,10 +218,20 @@ def main() -> None:
 
     load_dotenv(PROJECT_DIR / ".env")
 
-    token = os.environ.get("DISCORD_TOKEN")
-    if not token:
-        print("Set DISCORD_TOKEN in .env")
+    missing: list[str] = []
+    if not os.environ.get("DISCORD_TOKEN"):
+        missing.append("DISCORD_TOKEN    (bot token from Discord Developer Portal)")
+    if not os.environ.get("OLLIM_USER_NAME"):
+        missing.append("OLLIM_USER_NAME  (your first name — the bot will call you this)")
+    if not os.environ.get("OLLIM_BOT_NAME"):
+        missing.append("OLLIM_BOT_NAME   (your bot's name, e.g. Ollim)")
+    if missing:
+        print("Missing required env vars in .env:", file=sys.stderr)
+        for m in missing:
+            print(f"  {m}", file=sys.stderr)
         raise SystemExit(1)
+
+    token = os.environ["DISCORD_TOKEN"]
 
     from ollim_bot.auth import is_authenticated
 


### PR DESCRIPTION
## Summary
- Replace the DISCORD_TOKEN-only check in `main()` with a consolidated check of all 3 required env vars (`DISCORD_TOKEN`, `OLLIM_USER_NAME`, `OLLIM_BOT_NAME`)
- Shows ALL missing vars at once with descriptive example values, so first-time users see everything they need in a single error message
- `config.py`'s import-time check is unchanged -- it still catches missing vars for CLI commands that bypass `main()`

## Test plan
- [x] All 515 existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (ruff lint, ruff format, ty)
- [x] `test_config.py` tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)