### PR TITLE
fix: handle HTTP 401 in Discord REST API calls

### DIFF
--- a/src/ollim_bot/main.py
+++ b/src/ollim_bot/main.py
@@ -10,6 +10,7 @@ import logging
 import os
 import signal
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -185,8 +186,16 @@ def _discord_api(token: str, method: str, path: str, body: dict | None = None) -
     headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
     data = json.dumps(body).encode() if body else None
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req) as resp:
-        return json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            print("Discord API returned 401 — DISCORD_TOKEN appears invalid.", file=sys.stderr)
+            print("Check that DISCORD_TOKEN in .env matches the token from", file=sys.stderr)
+            print("Discord Developer Portal > Bot > Reset Token.", file=sys.stderr)
+            raise SystemExit(1) from e
+        raise
 
 
 def _dm_owner(token: str, message: str) -> None:


### PR DESCRIPTION
## Summary
- Add error handling to `_discord_api()` in `main.py` for HTTP failures
- A 401 Unauthorized response now prints an actionable message about an invalid `DISCORD_TOKEN` and exits with code 1
- All other HTTP errors re-raise unchanged (no speculative fallbacks)

This is the first failure point for an invalid Discord token — `_discord_api` is called before `bot.start()` during the Claude auth flow. Previously, a bad token would produce an opaque `urllib` traceback with no guidance on how to fix it.

## Changes
- Added `import urllib.error` (separate submodule from `urllib.request`)
- Wrapped `urlopen` in a `try/except urllib.error.HTTPError` that intercepts 401 specifically

## Test plan
- [x] All 515 existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (ruff lint, ruff format, ty)
- [ ] Manual: set an invalid `DISCORD_TOKEN` and run `ollim-bot` — should see actionable error message instead of traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)