### PR TITLE
fix: align thinking.max_tokens display name convention

### DIFF
--- a/src/ollim_bot/runtime_config.py
+++ b/src/ollim_bot/runtime_config.py
@@ -46,7 +46,7 @@ _KEY_META: dict[str, _KeyMeta] = {
     "model_fork": _KeyMeta("model.fork", "Default model for interactive forks", "model"),
     "thinking_main": _KeyMeta("thinking.main", "Extended thinking for main session", "bool"),
     "thinking_fork": _KeyMeta("thinking.fork", "Extended thinking for interactive forks", "bool"),
-    "max_thinking_tokens": _KeyMeta("max_thinking_tokens", "Token budget when thinking is on", "int"),
+    "max_thinking_tokens": _KeyMeta("thinking.max_tokens", "Token budget when thinking is on", "int"),
     "bg_fork_timeout": _KeyMeta("bg_fork_timeout", "Max background fork runtime (seconds)", "int"),
     "fork_idle_timeout": _KeyMeta("fork_idle_timeout", "Interactive fork idle timeout (minutes)", "int"),
     "permission_mode": _KeyMeta("permission_mode", "Default permission mode", "permission_mode"),


### PR DESCRIPTION
## Summary
- Changed the `_KEY_META` display name for `max_thinking_tokens` from `"max_thinking_tokens"` to `"thinking.max_tokens"` in `runtime_config.py`
- Aligns with the `/config` slash command `Choice(name="thinking.max_tokens", ...)` in `bot.py`
- Matches the dot-separated convention used by all other keys (`model.main`, `model.fork`, `thinking.main`, `thinking.fork`)

## Test plan
- [x] `uv run pytest` — all 515 tests pass
- [x] Pre-commit hooks (ruff lint, ruff format, ty) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)