### PR TITLE
fix: cross-platform PID check with corrupted file handling

### DIFF
--- a/src/ollim_bot/main.py
+++ b/src/ollim_bot/main.py
@@ -91,14 +91,35 @@ def _ensure_sdk_layout() -> None:
             target.symlink_to(source)
 
 
+def _is_bot_running(pid: int) -> bool:
+    """Check if a process is alive, with Linux-specific name verification."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        pass  # Process exists but we can't signal it — check name below
+
+    # On Linux, verify it's actually ollim-bot (not a recycled PID)
+    proc_cmdline = Path(f"/proc/{pid}/cmdline")
+    if proc_cmdline.exists():
+        return "ollim-bot" in proc_cmdline.read_bytes().decode(errors="replace")
+
+    # Non-Linux: process exists (os.kill didn't raise ProcessLookupError)
+    return True
+
+
 def _check_already_running() -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     if PID_FILE.exists():
-        pid = int(PID_FILE.read_text().strip())
-        proc_cmdline = Path(f"/proc/{pid}/cmdline")
-        if proc_cmdline.exists() and "ollim-bot" in proc_cmdline.read_bytes().decode(errors="replace"):
-            print(f"ollim-bot is already running (pid {pid})")
-            raise SystemExit(1)
+        try:
+            pid = int(PID_FILE.read_text().strip())
+        except (ValueError, OSError):
+            pass  # Corrupted PID file — overwrite below
+        else:
+            if _is_bot_running(pid):
+                print(f"ollim-bot is already running (pid {pid})")
+                raise SystemExit(1)
     PID_FILE.write_text(str(os.getpid()))
     atexit.register(PID_FILE.unlink, missing_ok=True)
 


### PR DESCRIPTION
## Summary
- Replace Linux-only `/proc/{pid}/cmdline` with `os.kill(pid, 0)` as the primary cross-platform "is process alive" check
- Keep `/proc/cmdline` as a Linux-specific enhancement to verify the process is actually ollim-bot (prevents false positives from recycled PIDs)
- Add error handling for corrupted PID files (non-numeric content, file race conditions)

## Test plan
- [x] All 515 existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (ruff lint, ruff format, ty)
- [ ] Manual: start bot, verify PID file created, start second instance — should print "already running" and exit
- [ ] Manual: corrupt PID file with non-numeric content, start bot — should overwrite and start normally
- [ ] Manual: write stale PID (dead process) to PID file, start bot — should overwrite and start normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)