### PR TITLE
feat: auto-init git repo in data directory

### DIFF
--- a/src/ollim_bot/main.py
+++ b/src/ollim_bot/main.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import signal
+import subprocess
 import sys
 import urllib.request
 from pathlib import Path
@@ -69,6 +70,11 @@ def _ensure_sdk_layout() -> None:
     from ollim_bot.subagents import install_agents
 
     DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Auto-init git for versioned backups
+    if not (DATA_DIR / ".git").exists():
+        subprocess.run(["git", "init"], cwd=DATA_DIR, capture_output=True)
+        print(f"Initialized git tracking in {DATA_DIR}")
 
     # Bundled agents → .claude/agents/
     install_agents()


### PR DESCRIPTION
## Summary
- Auto-initializes `~/.ollim-bot/` as a git repository on first startup if `.git` does not already exist
- Ensures the documentation claim ("automatically managed as a git repository") is accurate for new users
- Gives all users versioned backups of their agent working data by default

## Changes
- Added `subprocess` import to `main.py`
- Added git init check + initialization in `_ensure_sdk_layout()`, after `DATA_DIR.mkdir()` and before `install_agents()`

## Test plan
- [x] All 515 existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (ruff lint, ruff format, ty)
- [ ] Manual: remove `~/.ollim-bot/.git` and start bot — should print "Initialized git tracking" message
- [ ] Manual: start bot with existing `~/.ollim-bot/.git` — should skip silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)