### PR TITLE
fix: block save_context when fork is stale

### DIFF
--- a/src/ollim_bot/agent_tools.py
+++ b/src/ollim_bot/agent_tools.py
@@ -23,9 +23,11 @@ from ollim_bot.fork_state import (
     ForkExitAction,
     get_bg_fork_config,
     get_bg_tracking,
+    has_new_updates_since_fork,
     in_bg_fork,
     in_interactive_fork,
     is_busy,
+    is_fork_stale,
     request_enter_fork,
     set_exit_action,
 )
@@ -315,6 +317,20 @@ async def save_context(args: dict[str, Any]) -> dict[str, Any]:
         return _resp("Error: save_context is not available in background forks. Use report_updates instead.")
     if not in_interactive_fork():
         return _resp("Error: not in an interactive fork")
+
+    stale = is_fork_stale()
+    new_updates = has_new_updates_since_fork()
+    if stale or new_updates:
+        reasons = []
+        if stale:
+            reasons.append("the main session received new messages")
+        if new_updates:
+            reasons.append("new background updates arrived")
+        return _resp(
+            f"Error: cannot save — {' and '.join(reasons)} since this fork was created. "
+            "Promoting would discard that history. Use report_updates to summarize findings instead."
+        )
+
     set_exit_action(ForkExitAction.SAVE)
     await clear_pending_updates()
     return _resp("Context saved. Fork will be promoted to main session after you finish responding.")

--- a/src/ollim_bot/bot.py
+++ b/src/ollim_bot/bot.py
@@ -22,6 +22,7 @@ from ollim_bot.config import BOT_NAME, USER_NAME
 from ollim_bot.embeds import fork_enter_embed, fork_enter_view, fork_exit_embed
 from ollim_bot.fork_state import (
     ForkExitAction,
+    bump_main_generation,
     clear_prompted,
     enter_fork_requested,
     in_interactive_fork,
@@ -440,6 +441,7 @@ def create_bot() -> commands.Bot:
                     clear_prompted()
                 else:
                     cancel_message_collector()
+                    bump_main_generation()
                 await _check_fork_transitions(message.channel)
         except CLIConnectionError as e:
             log.error("CLIConnectionError in on_message: %s", e)

--- a/src/ollim_bot/fork_state.py
+++ b/src/ollim_bot/fork_state.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
@@ -133,40 +133,91 @@ def get_bg_fork_config() -> BgForkConfig:
 # Interactive fork state
 # ---------------------------------------------------------------------------
 
-_in_interactive_fork: bool = False
-_fork_exit_action: ForkExitAction = ForkExitAction.NONE
+
+@dataclass(slots=True)
+class InteractiveForkContext:
+    """Mutable state for the active interactive fork. Created on entry, None on exit."""
+
+    idle_timeout: int
+    main_gen_snapshot: int
+    updates_gen_snapshot: int
+    exit_action: ForkExitAction = ForkExitAction.NONE
+    last_activity: float = field(default_factory=time.monotonic)
+    prompted_at: float | None = None
+
+
+_fork_ctx: InteractiveForkContext | None = None
+
+# Global counters — meaningful independent of any fork.
+_main_generation: int = 0
+_updates_generation: int = 0
+
+# Enter-fork request state — transient signal from MCP tool to Agent.
 _enter_fork_requested: bool = False
 _enter_fork_topic: str | None = None
 _enter_fork_timeout: int = 10
-_fork_idle_timeout: int = 10
-_fork_last_activity: float = 0.0
-_fork_prompted_at: float | None = None
+
+
+def bump_main_generation() -> None:
+    """Increment main-session generation (call on each user message to main)."""
+    global _main_generation
+    _main_generation += 1
+
+
+def bump_updates_generation() -> None:
+    """Increment updates generation (call on each append_update)."""
+    global _updates_generation
+    _updates_generation += 1
+
+
+def main_generation() -> int:
+    """Current main-session generation counter."""
+    return _main_generation
+
+
+def is_fork_stale() -> bool:
+    """True if the main session received messages since this fork was created."""
+    if _fork_ctx is None:
+        return False
+    return _main_generation != _fork_ctx.main_gen_snapshot
+
+
+def has_new_updates_since_fork() -> bool:
+    """True if bg forks appended updates after this fork was created."""
+    if _fork_ctx is None:
+        return False
+    return _updates_generation != _fork_ctx.updates_gen_snapshot
 
 
 def in_interactive_fork() -> bool:
-    return _in_interactive_fork
+    return _fork_ctx is not None
 
 
 def set_interactive_fork(active: bool, *, idle_timeout: int | None = None) -> None:
     """Enter or exit interactive fork mode."""
     from ollim_bot import runtime_config
 
-    global _in_interactive_fork, _fork_exit_action, _fork_idle_timeout, _fork_prompted_at
-    _in_interactive_fork = active
-    _fork_idle_timeout = idle_timeout if idle_timeout is not None else runtime_config.load().fork_idle_timeout
-    _fork_exit_action = ForkExitAction.NONE
-    _fork_prompted_at = None
+    global _fork_ctx
+    if active:
+        timeout = idle_timeout if idle_timeout is not None else runtime_config.load().fork_idle_timeout
+        _fork_ctx = InteractiveForkContext(
+            idle_timeout=timeout,
+            main_gen_snapshot=_main_generation,
+            updates_gen_snapshot=_updates_generation,
+        )
+    else:
+        _fork_ctx = None
 
 
 def set_exit_action(action: ForkExitAction) -> None:
-    global _fork_exit_action
-    _fork_exit_action = action
+    assert _fork_ctx is not None
+    _fork_ctx.exit_action = action
 
 
 def pop_exit_action() -> ForkExitAction:
-    global _fork_exit_action
-    action = _fork_exit_action
-    _fork_exit_action = ForkExitAction.NONE
+    assert _fork_ctx is not None
+    action = _fork_ctx.exit_action
+    _fork_ctx.exit_action = ForkExitAction.NONE
     return action
 
 
@@ -198,37 +249,40 @@ def pop_enter_fork() -> tuple[str | None, int]:
 
 
 def idle_timeout() -> int:
-    return _fork_idle_timeout
+    assert _fork_ctx is not None
+    return _fork_ctx.idle_timeout
 
 
 def touch_activity() -> None:
-    global _fork_last_activity
-    _fork_last_activity = time.monotonic()
+    assert _fork_ctx is not None
+    _fork_ctx.last_activity = time.monotonic()
 
 
 def is_idle() -> bool:
     """True if interactive fork has been idle longer than idle_timeout."""
-    if not _in_interactive_fork:
+    if _fork_ctx is None:
         return False
-    return time.monotonic() - _fork_last_activity > _fork_idle_timeout * 60
+    return time.monotonic() - _fork_ctx.last_activity > _fork_ctx.idle_timeout * 60
 
 
 def prompted_at() -> float | None:
-    return _fork_prompted_at
+    if _fork_ctx is None:
+        return None
+    return _fork_ctx.prompted_at
 
 
 def set_prompted_at() -> None:
-    global _fork_prompted_at
-    _fork_prompted_at = time.monotonic()
+    assert _fork_ctx is not None
+    _fork_ctx.prompted_at = time.monotonic()
 
 
 def clear_prompted() -> None:
-    global _fork_prompted_at
-    _fork_prompted_at = None
+    assert _fork_ctx is not None
+    _fork_ctx.prompted_at = None
 
 
 def should_auto_exit() -> bool:
     """True if timeout prompt was sent and idle_timeout has passed since."""
-    if _fork_prompted_at is None:
+    if _fork_ctx is None or _fork_ctx.prompted_at is None:
         return False
-    return time.monotonic() - _fork_prompted_at > _fork_idle_timeout * 60
+    return time.monotonic() - _fork_ctx.prompted_at > _fork_ctx.idle_timeout * 60

--- a/src/ollim_bot/forks.py
+++ b/src/ollim_bot/forks.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 from ollim_bot.channel import get_channel
 from ollim_bot.config import TZ
 from ollim_bot.fork_state import (
+    bump_updates_generation,
     init_bg_tracking,
     set_bg_fork_config,
     set_busy,
@@ -67,6 +68,7 @@ async def append_update(message: str) -> None:
             }
             updates.insert(0, sentinel)
         atomic_write(_UPDATES_FILE, json.dumps(updates).encode())
+        bump_updates_generation()
         log.info("pending update appended (now %d): %.80s", len(updates), message)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,12 @@ def _reset_bg_tracking():
     import ollim_bot.fork_state as fork_state_mod
 
     fork_state_mod._bg_tracking.set(None)
+    fork_state_mod._main_generation = 0
+    fork_state_mod._updates_generation = 0
+    fork_state_mod._fork_ctx = None
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def data_dir(tmp_path, monkeypatch):
     """Redirect all data file paths to a temp directory."""
     import ollim_bot.forks as forks_mod

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -29,7 +29,7 @@ from ollim_bot.fork_state import (
     set_in_fork,
     set_interactive_fork,
 )
-from ollim_bot.forks import pop_pending_updates
+from ollim_bot.forks import append_update, pop_pending_updates
 
 # @tool decorator wraps the function in SdkMcpTool; .handler is the raw async fn
 _follow_up = follow_up_chain.handler
@@ -249,7 +249,7 @@ def test_exit_fork_in_interactive_fork():
 # --- save_context (interactive fork mode) ---
 
 
-def test_save_context_in_interactive_fork():
+def test_save_context_in_interactive_fork(data_dir):
     set_interactive_fork(True, idle_timeout=10)
 
     result = _run(_save_ctx({}))
@@ -271,6 +271,72 @@ def test_save_context_blocked_in_bg_fork_even_with_interactive():
     assert pop_exit_action() is ForkExitAction.NONE
     set_interactive_fork(False)
     set_in_fork(False)
+
+
+def test_save_context_blocked_when_stale(data_dir):
+    from ollim_bot.fork_state import bump_main_generation
+
+    set_interactive_fork(True, idle_timeout=10)
+    bump_main_generation()
+
+    result = _run(_save_ctx({}))
+
+    assert "Error" in result["content"][0]["text"]
+    assert "main session received new messages" in result["content"][0]["text"]
+    assert pop_exit_action() is ForkExitAction.NONE
+    set_interactive_fork(False)
+
+
+def test_save_context_blocked_when_new_updates(data_dir):
+    set_interactive_fork(True, idle_timeout=10)
+    _run(append_update("post-fork update"))
+
+    result = _run(_save_ctx({}))
+
+    assert "Error" in result["content"][0]["text"]
+    assert "new background updates arrived" in result["content"][0]["text"]
+    assert pop_exit_action() is ForkExitAction.NONE
+    set_interactive_fork(False)
+    _run(pop_pending_updates())
+
+
+def test_save_context_allowed_with_preexisting_updates(data_dir):
+    _run(append_update("pre-fork update"))
+    set_interactive_fork(True, idle_timeout=10)
+
+    result = _run(_save_ctx({}))
+
+    assert "promoted" in result["content"][0]["text"].lower()
+    assert pop_exit_action() is ForkExitAction.SAVE
+    set_interactive_fork(False)
+    _run(pop_pending_updates())
+
+
+def test_save_context_blocked_when_stale_and_new_updates(data_dir):
+    from ollim_bot.fork_state import bump_main_generation
+
+    set_interactive_fork(True, idle_timeout=10)
+    bump_main_generation()
+    _run(append_update("post-fork update"))
+
+    result = _run(_save_ctx({}))
+
+    text = result["content"][0]["text"]
+    assert "main session received new messages" in text
+    assert "new background updates arrived" in text
+    assert pop_exit_action() is ForkExitAction.NONE
+    set_interactive_fork(False)
+    _run(pop_pending_updates())
+
+
+def test_save_context_allowed_when_fresh(data_dir):
+    set_interactive_fork(True, idle_timeout=10)
+
+    result = _run(_save_ctx({}))
+
+    assert "promoted" in result["content"][0]["text"].lower()
+    assert pop_exit_action() is ForkExitAction.SAVE
+    set_interactive_fork(False)
 
 
 # --- report_updates (interactive fork mode) ---

--- a/tests/test_forks.py
+++ b/tests/test_forks.py
@@ -7,13 +7,17 @@ from unittest.mock import AsyncMock, MagicMock
 from ollim_bot.fork_state import (
     BgForkConfig,
     ForkExitAction,
+    bump_main_generation,
     get_bg_fork_config,
     get_bg_tracking,
+    has_new_updates_since_fork,
     idle_timeout,
     in_interactive_fork,
     init_bg_tracking,
     is_busy,
+    is_fork_stale,
     is_idle,
+    main_generation,
     pop_enter_fork,
     pop_exit_action,
     prompted_at,
@@ -174,7 +178,8 @@ def test_idle_after_timeout():
     import ollim_bot.fork_state as fork_state_mod
 
     set_interactive_fork(True, idle_timeout=10)
-    fork_state_mod._fork_last_activity = time.monotonic() - 601
+    assert fork_state_mod._fork_ctx is not None
+    fork_state_mod._fork_ctx.last_activity = time.monotonic() - 601
 
     assert is_idle() is True
 
@@ -224,7 +229,8 @@ def test_should_auto_exit_true_after_timeout():
     import ollim_bot.fork_state as fork_state_mod
 
     set_interactive_fork(True, idle_timeout=10)
-    fork_state_mod._fork_prompted_at = time.monotonic() - 601
+    assert fork_state_mod._fork_ctx is not None
+    fork_state_mod._fork_ctx.prompted_at = time.monotonic() - 601
 
     assert should_auto_exit() is True
 
@@ -237,6 +243,58 @@ def test_should_auto_exit_false_when_not_prompted():
     assert should_auto_exit() is False
 
     set_interactive_fork(False)
+
+
+# --- Generation counter (fork staleness) ---
+
+
+def test_main_generation_starts_at_zero():
+    assert main_generation() == 0
+
+
+def test_bump_main_generation():
+    bump_main_generation()
+    bump_main_generation()
+
+    assert main_generation() == 2
+
+
+def test_fork_not_stale_at_creation():
+    bump_main_generation()
+    set_interactive_fork(True, idle_timeout=10)
+
+    assert is_fork_stale() is False
+
+    set_interactive_fork(False)
+
+
+def test_fork_stale_after_main_message():
+    set_interactive_fork(True, idle_timeout=10)
+    bump_main_generation()
+
+    assert is_fork_stale() is True
+
+    set_interactive_fork(False)
+
+
+def test_no_new_updates_at_fork_creation(data_dir):
+    _run(append_update("pre-fork update"))
+    set_interactive_fork(True, idle_timeout=10)
+
+    assert has_new_updates_since_fork() is False
+
+    set_interactive_fork(False)
+    _run(pop_pending_updates())
+
+
+def test_new_updates_after_fork_creation(data_dir):
+    set_interactive_fork(True, idle_timeout=10)
+    _run(append_update("post-fork update"))
+
+    assert has_new_updates_since_fork() is True
+
+    set_interactive_fork(False)
+    _run(pop_pending_updates())
 
 
 # --- Background fork timeout ---


### PR DESCRIPTION
## Summary
- Consolidate 6 fork-scoped module globals into `InteractiveForkContext` dataclass — state exists only while a fork is active, snapshots captured automatically at construction
- Add generation counters for main-session messages and bg fork updates; `save_context` checks both against snapshots, blocking promotion when the main session had activity or new updates arrived after the fork started
- Pre-existing updates (already peeked by the fork via `prepend_context(clear=False)`) correctly do not block
- Make `data_dir` test fixture autouse to prevent accidental real-filesystem access

## Test plan
- [x] `test_fork_not_stale_at_creation` — snapshot at fork entry captures current generation
- [x] `test_fork_stale_after_main_message` — bump after fork entry is stale
- [x] `test_no_new_updates_at_fork_creation` — pre-fork updates don't count
- [x] `test_new_updates_after_fork_creation` — post-fork updates detected
- [x] `test_save_context_blocked_when_stale` — error returned, exit action stays NONE
- [x] `test_save_context_blocked_when_new_updates` — error when post-fork updates exist
- [x] `test_save_context_allowed_with_preexisting_updates` — pre-fork updates pass through
- [x] `test_save_context_blocked_when_stale_and_new_updates` — both reasons in error
- [x] `test_save_context_allowed_when_fresh` — success when neither condition holds
- [x] Full suite: 515 passed

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)