### PR TITLE
fix: remove/trim redundant docstrings in core utils

### DIFF
--- a/src/ollim_bot/__init__.py
+++ b/src/ollim_bot/__init__.py
@@ -1,1 +1,0 @@
-"""ollim-bot package."""

--- a/src/ollim_bot/auth.py
+++ b/src/ollim_bot/auth.py
@@ -15,7 +15,6 @@ _URL_PATTERN = re.compile(r"https://\S+")
 
 
 def _find_bundled_cli() -> str:
-    """Locate the Claude CLI bundled with claude-agent-sdk."""
     import claude_agent_sdk
 
     bundled = Path(claude_agent_sdk.__file__).parent / "_bundled" / _CLI_NAME
@@ -26,7 +25,6 @@ def _find_bundled_cli() -> str:
 
 
 def is_authenticated() -> bool:
-    """Check if Claude CLI is authenticated."""
     cli = _find_bundled_cli()
     result = subprocess.run([cli, "auth", "status", "--json"], capture_output=True, text=True, check=False)
     if result.returncode != 0:
@@ -36,7 +34,7 @@ def is_authenticated() -> bool:
 
 
 def start_login() -> tuple[str, subprocess.Popen[bytes]]:
-    """Start login flow with browser suppressed. Returns (auth_url, process).
+    """Start login flow with browser suppressed.
 
     The process blocks until the user completes auth via the URL.
     Caller must wait on the process after presenting the URL to the user.

--- a/src/ollim_bot/channel.py
+++ b/src/ollim_bot/channel.py
@@ -6,11 +6,9 @@ _channel: Any = None
 
 
 def init_channel(channel: object) -> None:
-    """Called once in on_ready after owner.create_dm()."""
     global _channel
     _channel = channel
 
 
 def get_channel() -> Any:
-    """Return the DM channel."""
     return _channel

--- a/src/ollim_bot/profile.py
+++ b/src/ollim_bot/profile.py
@@ -1,10 +1,4 @@
-"""User profile: IDENTITY.md and USER.md in DATA_DIR.
-
-IDENTITY.md defines the bot's persona -- how it speaks and relates to the user.
-USER.md provides context about the user -- who the bot is serving.
-
-Both are appended to the system prompt and editable by the agent.
-"""
+"""User profile files: IDENTITY.md (bot persona) and USER.md (user context)."""
 
 import logging
 

--- a/src/ollim_bot/storage.py
+++ b/src/ollim_bot/storage.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 
 
 def atomic_write(path: Path, data: bytes) -> None:
-    """Write data to path atomically via tempfile + os.replace."""
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
@@ -35,7 +34,6 @@ def atomic_write(path: Path, data: bytes) -> None:
 
 
 def safe_json_load(path: Path, default: Any = None) -> Any:
-    """Load JSON from path, returning *default* on missing file or decode error."""
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
@@ -46,10 +44,7 @@ def safe_json_load(path: Path, default: Any = None) -> Any:
 
 
 def save_attachment(filename: str, data: bytes) -> Path:
-    """Save attachment bytes to downloads dir, returning the path.
-
-    Handles filename collisions with numeric suffixes (file-2.txt, file-3.txt).
-    """
+    """Handles filename collisions with numeric suffixes."""
     DOWNLOADS_DIR.mkdir(parents=True, exist_ok=True)
     target = DOWNLOADS_DIR / filename
     if target.exists():
@@ -63,7 +58,6 @@ def save_attachment(filename: str, data: bytes) -> Path:
 
 
 def _find_repo(filepath: Path) -> Path | None:
-    """Walk up from filepath to find the nearest git repo root."""
     for parent in filepath.parents:
         if (parent / ".git").is_dir():
             return parent
@@ -89,7 +83,7 @@ def git_commit(filepath: Path, message: str) -> None:
 
 
 def git_rm_commit(filepath: Path, message: str) -> None:
-    """Remove a file from git and commit. No-op when no git repo is found."""
+    """No-op when no git repo is found."""
     repo = _find_repo(filepath)
     if repo is None:
         return
@@ -110,7 +104,7 @@ def git_rm_commit(filepath: Path, message: str) -> None:
 
 
 def parse_frontmatter(text: str) -> dict[str, object]:
-    """Extract YAML frontmatter as a dict. Returns {} on any parse failure."""
+    """Returns empty dict on any parse failure."""
     parts = text.split("---", 2)
     if len(parts) < 3:
         return {}
@@ -125,7 +119,6 @@ def parse_frontmatter(text: str) -> dict[str, object]:
 
 
 def _slugify(text: str, max_len: int = 50) -> str:
-    """Convert text to a filesystem-safe slug."""
     slug = text.lower()
     slug = re.sub(r"[^a-z0-9]+", "-", slug)
     slug = slug.strip("-")
@@ -169,7 +162,6 @@ def _serialize_md(item: T) -> str:
 
 
 def parse_md(text: str, cls: type[T]) -> T:
-    """Parse a single markdown file with YAML frontmatter into a dataclass."""
     parts = text.split("---", 2)
     if len(parts) < 3:
         raise ValueError("Missing YAML frontmatter delimiters")
@@ -196,7 +188,6 @@ def parse_md(text: str, cls: type[T]) -> T:
 
 
 def read_md_dir(dir_path: Path, cls: type[T]) -> list[T]:
-    """Read all .md files in a directory into dataclass instances."""
     if not dir_path.is_dir():
         return []
     result: list[T] = []
@@ -210,7 +201,6 @@ def read_md_dir(dir_path: Path, cls: type[T]) -> list[T]:
 
 
 def write_md(dir_path: Path, item: T, commit_msg: str) -> None:
-    """Write a single item as a .md file with a slug-based filename. Atomic write."""
     dir_path.mkdir(parents=True, exist_ok=True)
     slug = _slugify(item.message)  # type: ignore[attr-defined]
     target = dir_path / f"{slug}.md"
@@ -272,7 +262,6 @@ def append_jsonl(filepath: Path, item: T, commit_msg: str) -> None:
 
 
 def remove_jsonl(filepath: Path, item_id: str, cls: type[T], commit_msg: str) -> bool:
-    """Atomic write (temp file + rename) to prevent data loss on concurrent access."""
     items = read_jsonl(filepath, cls)
     filtered = [i for i in items if i.id != item_id]  # type: ignore[attr-defined]
     if len(filtered) == len(items):


### PR DESCRIPTION
## Summary
- Remove docstrings that restate the function name/signature from `__init__.py`, `channel.py`, `auth.py`, `storage.py`
- Trim multi-line docstrings to essential non-obvious info in `profile.py`, `storage.py`, `auth.py`
- 5 files changed, 22 lines of redundant documentation removed

## Test plan
- [x] All 701 tests pass
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Pre-commit hooks pass (ruff, ruff-format, ty)
- No behavior changes — docstring-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)