### PR TITLE
fix: remove redundant docstrings from fork system

### DIFF
--- a/src/ollim_bot/fork_state.py
+++ b/src/ollim_bot/fork_state.py
@@ -1,9 +1,4 @@
-"""Fork state: enums, dataclasses, contextvars, and accessor functions.
-
-Pure state management — no I/O, no async execution. Separated from forks.py
-so that consumers needing only fork state (permissions, streamer, embeds, etc.)
-don't depend on the heavier fork execution module.
-"""
+"""Fork state: enums, dataclasses, contextvars, and accessor functions."""
 
 from __future__ import annotations
 
@@ -136,8 +131,6 @@ def get_bg_fork_config() -> BgForkConfig:
 
 @dataclass(slots=True)
 class InteractiveForkContext:
-    """Mutable state for the active interactive fork. Created on entry, None on exit."""
-
     idle_timeout: int
     main_gen_snapshot: int
     updates_gen_snapshot: int
@@ -161,19 +154,16 @@ _enter_fork_timeout: int = 10
 
 
 def bump_main_generation() -> None:
-    """Increment main-session generation (call on each user message to main)."""
     global _main_generation
     _main_generation += 1
 
 
 def bump_updates_generation() -> None:
-    """Increment updates generation (call on each append_update)."""
     global _updates_generation
     _updates_generation += 1
 
 
 def main_generation() -> int:
-    """Current main-session generation counter."""
     return _main_generation
 
 
@@ -196,7 +186,6 @@ def in_interactive_fork() -> bool:
 
 
 def is_resumed_fork() -> bool:
-    """True if the current interactive fork was resumed from a prior bg session."""
     if _fork_ctx is None:
         return False
     return _fork_ctx.resume_session_id is not None
@@ -208,7 +197,6 @@ def set_interactive_fork(
     idle_timeout: int | None = None,
     resume_session_id: str | None = None,
 ) -> None:
-    """Enter or exit interactive fork mode."""
     from ollim_bot import runtime_config
 
     global _fork_ctx
@@ -237,13 +225,11 @@ def pop_exit_action() -> ForkExitAction:
 
 
 def bump_fork_turn() -> None:
-    """Increment the fork turn counter (call after each user message to fork)."""
     assert _fork_ctx is not None
     _fork_ctx.turn_count += 1
 
 
 def is_first_fork_turn() -> bool:
-    """True if the interactive fork is still on its first turn (turn 0)."""
     assert _fork_ctx is not None
     return _fork_ctx.turn_count < 1
 
@@ -260,7 +246,6 @@ def request_enter_fork(topic: str | None, *, idle_timeout: int) -> None:
 
 
 def pop_enter_fork() -> tuple[str | None, int]:
-    """Read and clear the enter-fork request. Returns (topic, idle_timeout)."""
     from ollim_bot import runtime_config
 
     cfg_timeout = runtime_config.load().fork_idle_timeout
@@ -286,7 +271,6 @@ def touch_activity() -> None:
 
 
 def is_idle() -> bool:
-    """True if interactive fork has been idle longer than idle_timeout."""
     if _fork_ctx is None:
         return False
     return time.monotonic() - _fork_ctx.last_activity > _fork_ctx.idle_timeout * 60

--- a/src/ollim_bot/forks.py
+++ b/src/ollim_bot/forks.py
@@ -48,9 +48,7 @@ class PendingUpdate(NamedTuple):
 
 
 async def append_update(message: str) -> None:
-    """Append a timestamped update to the pending updates file.
-
-    Lock protects the read-modify-write cycle so concurrent bg forks
+    """Lock protects the read-modify-write cycle so concurrent bg forks
     don't lose each other's updates.  Capped at MAX_PENDING_UPDATES —
     oldest entries are dropped when the cap is exceeded.
     """
@@ -73,7 +71,6 @@ async def append_update(message: str) -> None:
 
 
 def peek_pending_updates() -> list[PendingUpdate]:
-    """Read pending updates without clearing."""
     updates = safe_json_load(_UPDATES_FILE, [])
     return [PendingUpdate(ts=u["ts"], message=u["message"]) for u in updates]
 
@@ -138,7 +135,6 @@ def _tag_to_human_name(tag: str) -> str:
 async def _notify_fork_failure(
     channel: discord.abc.Messageable, tag: str, *, timed_out: bool = False, timeout_seconds: int = 0
 ) -> None:
-    """Best-effort DM notification when a bg fork fails or times out."""
     name = _tag_to_human_name(tag)
     if timed_out:
         msg = f"{name} timed out after {timeout_seconds // 60} minutes."
@@ -262,7 +258,6 @@ async def send_agent_dm(
     *,
     chain_ctx: ChainContext | None = None,
 ) -> None:
-    """Inject a prompt into the agent session and stream the response as a DM."""
     from ollim_bot.agent_tools import set_chain_context
     from ollim_bot.streamer import stream_to_channel
 


### PR DESCRIPTION
## Summary
- Trim multi-line module docstring in `fork_state.py` to single line
- Remove 12 docstrings that merely restate function name/signature across `fork_state.py` and `forks.py`
- Trim `append_update` docstring to keep only the non-obvious lock/cap semantics
- Preserved docstrings with genuinely non-obvious behavior (BgForkConfig.from_item, is_fork_stale, should_auto_exit, etc.)

## Test plan
- [x] All 701 tests pass
- [x] ruff check clean
- [x] ruff format clean
- [x] ty check clean
- [x] No functional code changes — docstring-only removals

🤖 Generated with [Claude Code](https://claude.com/claude-code)