### PR TITLE
fix: remove/trim redundant docstrings in agent_tools and hooks

### DIFF
--- a/src/ollim_bot/agent_tools.py
+++ b/src/ollim_bot/agent_tools.py
@@ -66,23 +66,21 @@ _chain_context_var: ContextVar[ChainContext | None] = ContextVar("_chain_context
 
 
 def set_chain_context(ctx: ChainContext | None) -> None:
-    """Set chain context global — used by foreground reminders."""
+    """Foreground reminders — global for the main thread."""
     global _chain_context
     _chain_context = ctx
 
 
 def set_fork_chain_context(ctx: ChainContext | None) -> None:
-    """Set chain context via contextvar — used by bg reminders."""
+    """Background reminders — contextvar-scoped per fork."""
     _chain_context_var.set(ctx)
 
 
 def _resp(text: str) -> dict[str, Any]:
-    """Build an MCP tool response dict."""
     return {"content": [{"type": "text", "text": text}]}
 
 
 def _source() -> Literal["main", "bg", "fork"]:  # duplicate-ok
-    """Return the execution context: main session, bg fork, or interactive fork."""
     if in_bg_fork():
         return "bg"
     if in_interactive_fork():
@@ -491,7 +489,7 @@ async def update_names(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_agent_server() -> Any:
-    """Build the discord MCP server. Lazy to avoid circular import via scheduling.__init__."""
+    """Lazy to avoid circular import via scheduling.__init__."""
     from ollim_bot.reminder_tools import add_reminder, cancel_reminder, list_reminders_tool
 
     return create_sdk_mcp_server(

--- a/src/ollim_bot/hooks.py
+++ b/src/ollim_bot/hooks.py
@@ -17,7 +17,6 @@ from ollim_bot.storage import git_commit
 
 
 def _resolve_tool_path(data: PreToolUseHookInput | PostToolUseHookInput) -> Path | None:
-    """Resolve ``file_path`` from tool input, returning None if absent."""
     file_path_str: str = data["tool_input"].get("file_path", "")
     if not file_path_str:
         return None
@@ -33,7 +32,6 @@ async def state_dir_guard(
     tool_use_id: str | None,
     context: HookContext,
 ) -> SyncHookJSONOutput:
-    """Block Write/Edit to the protected state/ directory."""
     data = cast(PreToolUseHookInput, input_data)
     resolved = _resolve_tool_path(data)
     if resolved is not None and resolved.is_relative_to(storage.STATE_DIR.resolve()):
@@ -52,7 +50,6 @@ async def auto_commit_hook(
     tool_use_id: str | None,
     context: HookContext,
 ) -> SyncHookJSONOutput:
-    """Auto-commit files after Write/Edit tool calls in DATA_DIR."""
     data = cast(PostToolUseHookInput, input_data)
     resolved = _resolve_tool_path(data)
     if resolved is None:


### PR DESCRIPTION
## Summary
- Remove docstrings that restate the function name/signature from `_resp`, `_source`, `_resolve_tool_path`, `state_dir_guard`, and `auto_commit_hook`
- Trim `set_chain_context`, `set_fork_chain_context`, and `build_agent_server` docstrings to keep only non-obvious information
- Per python-principles audit of agent tools and hooks files

## Test plan
- [x] All 701 tests pass
- [x] Ruff lint and format checks pass
- [x] Pre-commit hooks (ruff, ty) pass
- [x] No behavioral changes — docstring-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)