### PR TITLE
fix: trim unnecessary docstrings in sessions & inquiries

### DIFF
--- a/src/ollim_bot/inquiries.py
+++ b/src/ollim_bot/inquiries.py
@@ -18,8 +18,7 @@ MAX_AGE = 7 * 24 * 3600  # 7 days
 
 
 def register(prompt: str) -> str:
-    """IDs are 8 hex chars; short enough for custom_id but collision risk is negligible at this scale."""
-    uid = uuid4().hex[:8]
+    uid = uuid4().hex[:8]  # 8 hex chars: short enough for custom_id, collision-safe at this scale
     data = _read()
     data[uid] = {"prompt": prompt, "ts": time.time()}
     _write(data)
@@ -27,7 +26,6 @@ def register(prompt: str) -> str:
 
 
 def peek(uid: str) -> str | None:
-    """Check if an inquiry exists without consuming it."""
     data = _read()
     entry = data.get(uid)
     return entry["prompt"] if entry else None

--- a/src/ollim_bot/sessions.py
+++ b/src/ollim_bot/sessions.py
@@ -121,24 +121,22 @@ class _ForkMessageRecord(TypedDict):
 
 
 def start_message_collector() -> None:
-    """Initialize a contextvar list to collect Discord message IDs during a bg fork."""
     _msg_collector.set([])
 
 
 def cancel_message_collector() -> None:
-    """Discard any collected message IDs without writing. Safe to call if already flushed."""
+    """Safe to call if already flushed."""
     _msg_collector.set(None)
 
 
 def track_message(message_id: int) -> None:
-    """Append a Discord message ID to the active collector. No-op if no collector."""
+    """No-op if no collector is active."""
     collector = _msg_collector.get()
     if collector is not None:
         collector.append(message_id)
 
 
 def flush_message_collector(fork_session_id: str, parent_session_id: str | None) -> None:
-    """Write collected message IDs to fork_messages.json and clear the collector."""
     collector = _msg_collector.get()
     _msg_collector.set(None)
     if not collector:
@@ -158,17 +156,13 @@ def flush_message_collector(fork_session_id: str, parent_session_id: str | None)
 
 
 class ForkLookup(NamedTuple):
-    """Result of looking up a fork session by Discord message ID."""
-
     session_id: str | None
     expired: bool
     ts: float | None = None
 
 
 def lookup_fork_session(message_id: int) -> ForkLookup:
-    """Look up a fork session by Discord message ID.
-
-    Returns (session_id, expired=False) for live records,
+    """Returns (session_id, expired=False) for live records,
     (None, expired=True) for TTL-expired records,
     (None, expired=False) for unknown message IDs.
     """


### PR DESCRIPTION
## Summary
- Remove docstrings that restate function name/signature in `sessions.py` (`start_message_collector`, `flush_message_collector`, `ForkLookup` class)
- Trim docstrings to keep only non-obvious info (`cancel_message_collector`, `track_message`, `lookup_fork_session`)
- Remove `peek` docstring in `inquiries.py`; convert `register` docstring to inline comment on the `uuid4().hex[:8]` line

## Test plan
- [x] All 701 tests pass
- [x] ruff check + format clean
- [x] No behavioral changes (docstring-only edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)