### PR TITLE
fix: remove/trim unnecessary docstrings in bot, streamer, permissions, prompts

### DIFF
--- a/src/ollim_bot/bot.py
+++ b/src/ollim_bot/bot.py
@@ -55,7 +55,7 @@ def get_owner_id() -> int | None:
 
 
 def is_owner(user_id: int) -> bool:
-    """Check if user is the bot owner. Allows all when owner not yet resolved."""
+    """Allows all when owner not yet resolved (before on_ready)."""
     return _owner_id is None or user_id == _owner_id
 
 
@@ -85,7 +85,6 @@ def _detect_image_type(data: bytes) -> _ImageMime | None:
 async def _process_attachments(
     attachments: list[discord.Attachment],
 ) -> tuple[list[dict[str, str]], list[Path]]:
-    """Base64-encode images, save other attachments to disk."""
     if not attachments:
         return [], []
     raw_bytes = await asyncio.gather(*(att.read() for att in attachments))
@@ -109,7 +108,6 @@ _MAX_QUOTE_LEN = 500
 
 
 def _quote_message(msg: discord.Message) -> str:
-    """Extract quotable text from a message's content or embeds."""
     if msg.content:
         text = msg.content
     elif msg.embeds:
@@ -130,7 +128,6 @@ def _quote_message(msg: discord.Message) -> str:
 
 
 def create_bot() -> commands.Bot:
-    """Image attachments are sniffed by magic bytes rather than Discord's unreliable content_type."""
     intents = discord.Intents.default()
     intents.message_content = True
 
@@ -151,7 +148,7 @@ def create_bot() -> commands.Bot:
         *,
         images: list[dict[str, str]] | None = None,
     ) -> None:
-        """typing -> stream (stream_to_channel sets channel). Caller must hold agent.lock()."""
+        """Caller must hold agent.lock()."""
         await channel.typing()
         await stream_to_channel(channel, agent.stream_chat(prompt, images=images))
 

--- a/src/ollim_bot/permissions.py
+++ b/src/ollim_bot/permissions.py
@@ -56,7 +56,7 @@ def set_dont_ask(value: bool) -> None:
 
 
 def is_denied(label: str) -> bool:
-    """Check (and consume) whether a tool label was denied by canUseTool."""
+    """Consumes the denial on read — returns True at most once per label."""
     if label in _denied_labels:
         _denied_labels.discard(label)
         return True
@@ -64,7 +64,7 @@ def is_denied(label: str) -> bool:
 
 
 def clear_denied() -> None:
-    """Clear stale denied labels. Called before each new response."""
+    """Called before each new response."""
     _denied_labels.clear()
 
 
@@ -87,7 +87,7 @@ def session_allow(tool_name: str) -> None:
 
 
 def resolve_approval(message_id: int, emoji: str) -> None:
-    """Resolve a pending approval. Safe to call from any context."""
+    """Safe to call from any context (no-op if no pending approval)."""
     entry = _pending.get(message_id)
     if entry is None or entry.event.is_set():
         return
@@ -104,7 +104,7 @@ def cancel_pending() -> None:
 
 
 def reset() -> None:
-    """Clear session-allowed set and cancel all pending approvals. Called on /clear."""
+    """Called on /clear."""
     cancel_pending()
     _session_allowed.clear()
     _denied_labels.clear()

--- a/src/ollim_bot/prompts.py
+++ b/src/ollim_bot/prompts.py
@@ -8,7 +8,6 @@ from ollim_bot.profile import load_profile
 
 
 def build_system_prompt() -> str:
-    """Assemble the system prompt from profile files and operational instructions."""
     profile = load_profile()
 
     operational = f"""\
@@ -250,7 +249,6 @@ def fork_bg_resume_prompt(inquiry_prompt: str) -> str:
 
 
 def fork_resume_notice(fork_ts: float | None) -> str:
-    """Build the staleness notice for a resumed bg fork."""
     age = ""
     if fork_ts is not None:
         iso = datetime.fromtimestamp(fork_ts, tz=TZ).isoformat()

--- a/src/ollim_bot/streamer.py
+++ b/src/ollim_bot/streamer.py
@@ -52,7 +52,6 @@ class StreamParser:
         self.active_task_label: str | None = None
 
     async def feed(self, event: dict[str, Any]) -> AsyncGenerator[str | StreamStatus, None]:
-        """Process one SSE event dict."""
         etype = event.get("type")
 
         if etype == "content_block_start":


### PR DESCRIPTION
## Summary
- Remove docstrings that merely restate the function name/signature from `bot.py`, `streamer.py`, and `prompts.py`
- Trim docstrings in `permissions.py` and `bot.py` to keep only the non-obvious part (e.g. consume-on-read semantics, caller contract, lifecycle context)
- Per python-principles audit: docstrings should add information beyond what the signature already communicates

## Test plan
- [x] All 701 tests pass (`uv run pytest`)
- [x] Linting clean (`uv run ruff check`)
- [x] Formatting clean (`uv run ruff format --check`)
- No e2e needed — docstring-only changes cannot affect behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)