### PR TITLE
fix: remove redundant docstrings from infrastructure modules

### DIFF
--- a/src/ollim_bot/ping_budget.py
+++ b/src/ollim_bot/ping_budget.py
@@ -29,7 +29,6 @@ class BudgetState:
 
 
 def _refill(state: BudgetState) -> BudgetState:
-    """Compute accumulated refills since last_refill, cap at capacity."""
     now = datetime.now(TZ)
     last = datetime.fromisoformat(state.last_refill)
     elapsed_minutes = (now - last).total_seconds() / 60
@@ -39,7 +38,6 @@ def _refill(state: BudgetState) -> BudgetState:
 
 
 def _reset_daily(state: BudgetState) -> BudgetState:
-    """Reset daily counters if date is stale."""
     today = datetime.now(TZ).date().isoformat()
     if state.critical_reset_date != today:
         state = replace(state, critical_used=0, critical_reset_date=today)
@@ -49,7 +47,7 @@ def _reset_daily(state: BudgetState) -> BudgetState:
 
 
 def load() -> BudgetState:
-    """Read budget from disk; refill based on elapsed time; create defaults if missing."""
+    """Refill-on-read: reads state, applies time-based refill, and writes back."""
     now = datetime.now(TZ)
     today = now.date().isoformat()
 
@@ -81,7 +79,6 @@ def save(state: BudgetState) -> None:
 
 
 def try_use() -> bool:
-    """Consume 1 ping if available. Returns False if insufficient."""
     state = load()
     if state.available < 1.0:
         return False
@@ -96,7 +93,6 @@ def record_critical() -> None:
 
 
 def get_status() -> str:
-    """Formatted budget status for preamble injection."""
     state = load()
     avail = int(state.available)
     base = f"budget: {avail}/{state.capacity}"
@@ -109,7 +105,6 @@ def get_status() -> str:
 
 
 def get_full_status() -> str:
-    """Extended status for /ping-budget command (includes daily totals)."""
     state = load()
     status = get_status()
     parts = [status]
@@ -121,19 +116,16 @@ def get_full_status() -> str:
 
 
 def set_capacity(capacity: int) -> None:
-    """Update capacity, preserving other state."""
     state = load()
     save(replace(state, capacity=capacity))
 
 
 def set_refill_rate(minutes: int) -> None:
-    """Update refill rate, preserving other state."""
     state = load()
     save(replace(state, refill_rate_minutes=minutes))
 
 
 def minutes_to_next_refill() -> int | None:
-    """Minutes until next ping refill, or None if at capacity."""
     state = load()
     if state.available >= state.capacity:
         return None

--- a/src/ollim_bot/runtime_config.py
+++ b/src/ollim_bot/runtime_config.py
@@ -70,7 +70,6 @@ VALID_KEYS = frozenset(_KEY_META)
 
 
 def _migrate_thinking(value: object) -> str:
-    """Convert legacy bool thinking values to string mode."""
     if value is True:
         return "adaptive"
     if value is False:
@@ -79,7 +78,6 @@ def _migrate_thinking(value: object) -> str:
 
 
 def load() -> RuntimeConfig:
-    """Read config from disk; return defaults if missing or corrupt."""
     data = safe_json_load(CONFIG_FILE)
     if not data:
         return _DEFAULTS
@@ -97,7 +95,6 @@ def save(config: RuntimeConfig) -> None:
 
 
 def _parse_value(key: str, raw: str) -> str | int | bool | None:
-    """Parse a raw string value for the given key. Raises ValueError on invalid input."""
     meta = _KEY_META[key]
     if meta.kind == "model":
         lowered = raw.lower().strip()
@@ -145,7 +142,6 @@ def _parse_value(key: str, raw: str) -> str | int | bool | None:
 
 
 def set_value(key: str, raw: str) -> RuntimeConfig:
-    """Parse, validate, save, and return the updated config."""
     if key not in _KEY_META:
         raise ValueError(f"unknown key: {key}")
     parsed = _parse_value(key, raw)
@@ -156,7 +152,6 @@ def set_value(key: str, raw: str) -> RuntimeConfig:
 
 
 def _format_value(key: str, value: str | int | bool | None) -> str:
-    """Format a single value for display."""
     meta = _KEY_META[key]
     default = getattr(_DEFAULTS, key)
     is_default = value == default
@@ -196,7 +191,6 @@ def _format_value(key: str, value: str | int | bool | None) -> str:
 
 
 def format_all() -> str:
-    """Formatted display of all settings."""
     config = load()
     lines: list[str] = []
     for key, meta in _KEY_META.items():
@@ -209,7 +203,6 @@ def format_all() -> str:
 
 
 def format_one(key: str) -> str:
-    """Formatted display of one setting."""
     config = load()
     meta = _KEY_META[key]
     value = getattr(config, key)

--- a/src/ollim_bot/skills.py
+++ b/src/ollim_bot/skills.py
@@ -57,7 +57,6 @@ def skill_name(item: Routine | Reminder | WebhookSpec) -> str:
 
 
 def _build_skills_instruction(skill_names: list[str]) -> str:
-    """Format a REQUIRED SKILLS instruction block for the SKILL.md body."""
     lines = ["REQUIRED SKILLS: You must invoke these skills before proceeding:"]
     for name in skill_names:
         lines.append(f"  - Skill({name})")
@@ -65,7 +64,6 @@ def _build_skills_instruction(skill_names: list[str]) -> str:
 
 
 def build_skill_md(item: Routine | Reminder | WebhookSpec, *, name: str | None = None) -> str:
-    """Generate SKILL.md content from a Routine, Reminder, or WebhookSpec."""
     if name is None:
         name = skill_name(item)
     description = getattr(item, "description", "") or name
@@ -101,7 +99,6 @@ def build_skill_md(item: Routine | Reminder | WebhookSpec, *, name: str | None =
 
 
 def ensure_skill(item: Routine | Reminder | WebhookSpec) -> str:
-    """Write SKILL.md for the item. Returns skill name."""
     name = skill_name(item)
     skill_dir = SKILLS_DIR / name
     skill_dir.mkdir(parents=True, exist_ok=True)
@@ -110,7 +107,6 @@ def ensure_skill(item: Routine | Reminder | WebhookSpec) -> str:
 
 
 def remove_skill(name: str) -> None:
-    """Remove a generated skill directory."""
     skill_dir = SKILLS_DIR / name
     if skill_dir.is_dir():
         shutil.rmtree(skill_dir)
@@ -118,7 +114,6 @@ def remove_skill(name: str) -> None:
 
 
 def cleanup_stale_skills(active_names: set[str]) -> None:
-    """Remove generated skill dirs not in the active set."""
     if not SKILLS_DIR.is_dir():
         return
     for path in SKILLS_DIR.iterdir():

--- a/src/ollim_bot/subagents.py
+++ b/src/ollim_bot/subagents.py
@@ -25,7 +25,6 @@ _AGENTS_DIR = DATA_DIR / ".claude" / "agents"
 
 
 def _expand(text: str) -> str:
-    """Expand {USER_NAME} and {BOT_NAME} template variables."""
     return text.replace("{USER_NAME}", USER_NAME).replace("{BOT_NAME}", BOT_NAME)
 
 
@@ -46,7 +45,6 @@ def install_agents() -> None:
 
 
 def _extract_tools(path: Path) -> tuple[str, list[str]] | None:
-    """Extract (name, tools) from a single agent spec's YAML frontmatter."""
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -70,7 +68,6 @@ def _extract_tools(path: Path) -> tuple[str, list[str]] | None:
 
 
 def load_agent_tool_sets() -> dict[str, list[str]]:
-    """Read tool declarations from installed agent specs for policy validation."""
     tool_sets: dict[str, list[str]] = {}
     if not _AGENTS_DIR.is_dir():
         return tool_sets

--- a/src/ollim_bot/tool_policy.py
+++ b/src/ollim_bot/tool_policy.py
@@ -112,7 +112,6 @@ def _could_match_state_dir(glob_pattern: str) -> bool:
 
 
 def validate_pattern(pattern: str) -> list[str]:
-    """Return error messages for a single tool pattern. Empty list = valid."""
     errors: list[str] = []
 
     pattern = pattern.strip()
@@ -140,7 +139,6 @@ def validate_pattern(pattern: str) -> list[str]:
 
 
 def validate_tool_set(patterns: list[str], source: str) -> list[ToolPatternError]:
-    """Validate a complete tool set declaration."""
     results: list[ToolPatternError] = []
     for pattern in patterns:
         for msg in validate_pattern(pattern):
@@ -155,8 +153,6 @@ def validate_tool_set(patterns: list[str], source: str) -> list[ToolPatternError
 
 
 def scan_all(tool_sets: dict[str, list[str]]) -> list[ToolPatternError]:
-    """Validate all tool declarations."""
-
     errors: list[ToolPatternError] = []
     for source, tools in tool_sets.items():
         errors.extend(validate_tool_set(tools, source))
@@ -226,7 +222,6 @@ DEFAULT_BG_TOOLS: list[str] = [
 
 
 def validate_dispatch(allowed_tools: list[str] | None, source: str) -> bool:
-    """Validate tool patterns before background fork dispatch. Returns True if valid."""
     if allowed_tools is None:
         return True
     errors = validate_tool_set(allowed_tools, source=source)
@@ -285,7 +280,6 @@ def _yaml_config_path() -> Path:
 
 
 def reset_yaml_cache() -> None:
-    """Reset the YAML config cache. For tests."""
     global _yaml_cache_mtime, _yaml_cache_data
     _yaml_cache_mtime = 0.0
     _yaml_cache_data = {}


### PR DESCRIPTION
## Summary
- Removed docstrings that merely restate the function signature from `ping_budget.py`, `runtime_config.py`, `skills.py`, `subagents.py`, and `tool_policy.py`
- Trimmed `load()` docstring in `ping_budget.py` to describe the non-obvious refill-on-read behavior
- Kept genuinely useful docstrings (`save`, `record_critical`, `build_main_tools`, `build_bg_tools`, `skill_name`, etc.)

## Test plan
- [x] All 701 tests pass
- [x] Ruff lint and format checks pass
- [x] No behavioral changes (docstring-only removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)