### PR TITLE
fix: trim redundant docstrings in scheduling & google

### DIFF
--- a/src/ollim_bot/google/auth.py
+++ b/src/ollim_bot/google/auth.py
@@ -39,7 +39,6 @@ class _SilentHandler(wsgiref.simple_server.WSGIRequestHandler):
 
 
 def get_credentials() -> Credentials:
-    """First run opens a browser for consent. Subsequent runs use token.json."""
     creds = None
     if TOKEN_FILE.exists():
         creds = Credentials.from_authorized_user_file(str(TOKEN_FILE), SCOPES)
@@ -72,16 +71,11 @@ def get_credentials() -> Credentials:
 
 
 def get_service(api: str, version: str) -> Resource:
-    """Credentials are obtained (and refreshed) on every call via get_credentials()."""
     return _build(api, version, credentials=get_credentials())
 
 
 def is_google_connected() -> bool:
-    """True if a Google token exists that doesn't require a new consent flow.
-
-    Does not attempt a network refresh — a stale token that can refresh still
-    returns True; actual refresh happens lazily via get_credentials().
-    """
+    """Does not attempt a network refresh; a stale but refreshable token returns True."""
     if not TOKEN_FILE.exists():
         return False
     creds = Credentials.from_authorized_user_file(str(TOKEN_FILE), SCOPES)
@@ -89,11 +83,6 @@ def is_google_connected() -> bool:
 
 
 def check_and_clear_revoked() -> bool:
-    """Return True and delete the marker if a token revocation was detected.
-
-    Written by get_credentials() on non-retryable RefreshError (invalid_grant).
-    Consumed by the scheduler to trigger a user-facing ping.
-    """
     if not _REVOKED_MARKER.exists():
         return False
     _REVOKED_MARKER.unlink(missing_ok=True)

--- a/src/ollim_bot/google/gmail.py
+++ b/src/ollim_bot/google/gmail.py
@@ -96,13 +96,13 @@ def _fmt_date(internal_date: str) -> str:
 
 
 def _short_sender(from_header: str) -> str:
-    """Extract display name from 'Name <email>' format."""
     if "<" in from_header:
         return from_header.split("<")[0].strip().strip('"')
     return from_header
 
 
 def _decode_body(payload: dict, mime_type: str) -> str:
+    """Recursively search MIME parts for mime_type and return decoded content."""
     mime = payload.get("mimeType", "")
 
     if mime == mime_type and payload.get("body", {}).get("data"):

--- a/src/ollim_bot/scheduling/preamble.py
+++ b/src/ollim_bot/scheduling/preamble.py
@@ -53,8 +53,6 @@ def _convert_dow(dow: str) -> str:
 
 @dataclass(frozen=True, slots=True)
 class ScheduleEntry:
-    """One upcoming bg task in the forward schedule."""
-
     id: str
     fire_time: datetime
     label: str  # e.g. "Chore-time routine" or "Chain reminder (2/4)"
@@ -72,7 +70,6 @@ _TRUNCATE_LEN = 60
 
 
 def _routine_next_fire(routine: Routine, after: datetime) -> datetime | None:
-    """Get next fire time for a routine after a given datetime."""
     parts = routine.cron.split()
     trigger = CronTrigger(
         minute=parts[0],
@@ -95,7 +92,6 @@ def _routine_prev_fire(routine: Routine, now: datetime) -> datetime | None:
 
 
 def _entry_description(item: Routine | Reminder) -> str:
-    """Use YAML description if available, else truncate message."""
     if item.description:
         return item.description
     msg = item.message.replace("\n", " ").strip()
@@ -105,7 +101,6 @@ def _entry_description(item: Routine | Reminder) -> str:
 
 
 def _entry_label(item: Routine | Reminder) -> str:
-    """Build the label prefix."""
     if isinstance(item, Routine):
         return item.description or "Routine"
     if item.max_chain > 0:
@@ -116,7 +111,6 @@ def _entry_label(item: Routine | Reminder) -> str:
 
 
 def _entry_file_path(item: Routine | Reminder) -> str:
-    """Relative file path for the agent to Read."""
     if isinstance(item, Routine):
         return f"routines/{item.id}.md"
     return f"reminders/{item.id}.md"
@@ -128,7 +122,6 @@ def build_upcoming_schedule(
     *,
     current_id: str,
 ) -> list[ScheduleEntry]:
-    """Build the forward schedule for the bg preamble."""
     now = datetime.now(TZ)
     base_cutoff = now + timedelta(hours=_BASE_WINDOW_HOURS)
     max_cutoff = now + timedelta(hours=_MAX_WINDOW_HOURS)
@@ -199,7 +192,6 @@ def build_bg_preamble(
     busy: bool = False,
     bg_config: BgForkConfig | None = None,
 ) -> str:
-    """Build BG_PREAMBLE with budget status, schedule, and config."""
     now = datetime.now(TZ)
     config = bg_config or BgForkConfig()
 

--- a/src/ollim_bot/scheduling/reminders.py
+++ b/src/ollim_bot/scheduling/reminders.py
@@ -51,7 +51,6 @@ class Reminder:
         allowed_tools: list[str] | None = None,
         skills: list[str] | None = None,
     ) -> "Reminder":
-        """Create a reminder, auto-setting chain_parent to own ID for chain roots."""
         run_at = (datetime.now(TZ) + timedelta(minutes=delay_minutes)).isoformat()
         rid = uuid4().hex[:8]
         assert chain_depth <= max_chain, f"chain_depth ({chain_depth}) > max_chain ({max_chain})"

--- a/src/ollim_bot/scheduling/scheduler.py
+++ b/src/ollim_bot/scheduling/scheduler.py
@@ -80,12 +80,7 @@ def _check_corrupt_files(
     kind: Literal["routine", "reminder"],
     all_files: list[Path],
 ) -> None:
-    """Surface corrupt routine/reminder files to the agent via pending_updates.
-
-    Compares the number of .md files on disk to the number successfully parsed.
-    Reports once per directory (deduped by kind); clears when the problem resolves.
-    *all_files* is passed from the caller to avoid re-globbing the directory.
-    """
+    """Surface corrupt routine/reminder files to the agent via pending_updates."""
     skipped = len(all_files) - loaded_count
     problem_key = f"corrupt_{kind}_files"
 
@@ -113,12 +108,7 @@ def _check_corrupt_files(
 
 
 def _merge_skill_tools(config: BgForkConfig, skill_names: list[str] | None) -> BgForkConfig:
-    """Add Skill(<name> *) patterns to allowed_tools for background fork dispatch.
-
-    The SDK handles skill content loading and allowed-tools enforcement
-    natively (resolved before can_use_tool callback). We only need to
-    ensure the Skill tool itself is permitted for each skill name.
-    """
+    """Add Skill(<name> *) patterns to allowed_tools for background fork dispatch."""
     if not skill_names:
         return config
     additions = [f"Skill({name} *)" for name in skill_names]
@@ -311,7 +301,6 @@ _INTERNAL_JOBS = {"sync_all", "check_fork_timeout", "check_for_update"}
 
 
 def _on_job_missed(event: JobExecutionEvent) -> None:
-    """Surface user-facing job misfires to pending_updates."""
     job_id: str = event.job_id
     if job_id in _INTERNAL_JOBS:
         return


### PR DESCRIPTION
## Summary
- Remove docstrings that restate the function/class name in `scheduling/reminders.py`, `scheduling/scheduler.py`, `scheduling/preamble.py`, `google/auth.py`, and `google/gmail.py`
- Trim multi-line docstrings to essential first line where the extra lines were implementation details (`_check_corrupt_files`, `_merge_skill_tools`, `is_google_connected`)
- Remove `check_and_clear_revoked` docstring entirely (name + return type are sufficient)
- Add missing docstring to `_decode_body` (non-obvious recursive MIME traversal)

## Test plan
- [x] `uv run pytest` — 701 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — 79 files already formatted
- No e2e needed: docstring-only changes cannot affect behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)