### PR TITLE
fix: remove redundant docstrings from entry points and updater

### DIFF
--- a/src/ollim_bot/doctor.py
+++ b/src/ollim_bot/doctor.py
@@ -68,7 +68,6 @@ def _count_md_files(directory: Path) -> int:
 
 
 def check_routines() -> list[CheckResult]:
-    """Parse routines, validate cron, compute next fire times — single pass."""
     from ollim_bot.scheduling.preamble import _routine_next_fire
     from ollim_bot.scheduling.routines import ROUTINES_DIR
 
@@ -336,7 +335,6 @@ def _print_results(sections: list[tuple[str, list[CheckResult]]]) -> int:
 
 
 def run_doctor_command(args: list[str]) -> None:
-    """Entry point for ``ollim-bot doctor``."""
     from dotenv import load_dotenv
 
     from ollim_bot.storage import PROJECT_DIR

--- a/src/ollim_bot/main.py
+++ b/src/ollim_bot/main.py
@@ -1,4 +1,4 @@
-"""Entry point for ollim-bot."""
+"""CLI entry point and command router."""
 
 from __future__ import annotations
 
@@ -65,12 +65,7 @@ examples:
 
 
 def _ensure_sdk_layout() -> None:
-    """Set up the SDK-expected directory structure in DATA_DIR.
-
-    - Copies bundled agent specs to .claude/agents/ (with template expansion)
-    - Symlinks .claude/skills/ -> ../skills/ for SDK skill discovery
-    - Symlinks spec docs into DATA_DIR for agent access
-    """
+    """Set up the SDK-expected directory structure in DATA_DIR."""
     from ollim_bot.profile import bootstrap_identity
     from ollim_bot.subagents import install_agents
 
@@ -111,7 +106,6 @@ def _ensure_sdk_layout() -> None:
 
 
 def _is_bot_running(pid: int) -> bool:
-    """Check if a process is alive, with platform-specific verification."""
     if sys.platform == "win32":
         # Windows: OpenProcess returns 0 for non-existent processes
         import ctypes
@@ -155,7 +149,6 @@ def _check_already_running() -> None:
 
 
 def _dispatch_subcommand() -> bool:
-    """Route CLI subcommands. Returns True if handled."""
     if len(sys.argv) < 2:
         return False
     cmd = sys.argv[1]
@@ -189,7 +182,6 @@ log = logging.getLogger(__name__)
 
 
 async def _notify_exit(bot: Bot, reason: str) -> None:
-    """Best-effort DM to owner before the process exits."""
     from ollim_bot.bot import get_owner_id
 
     owner_id = get_owner_id()
@@ -202,7 +194,6 @@ async def _notify_exit(bot: Bot, reason: str) -> None:
 
 
 async def _run(bot: Bot, token: str) -> None:
-    """Run the bot, DM the owner on unexpected exits."""
     loop = asyncio.get_running_loop()
     _background_tasks: set[asyncio.Task[None]] = set()
 
@@ -249,7 +240,6 @@ async def _run(bot: Bot, token: str) -> None:
 
 
 def _discord_api(token: str, method: str, path: str, body: dict | None = None) -> dict:
-    """Make a Discord REST API call."""
     url = f"https://discord.com/api/v10{path}"
     headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
     data = json.dumps(body).encode() if body else None
@@ -277,7 +267,6 @@ def _discord_api(token: str, method: str, path: str, body: dict | None = None) -
 
 
 def _dm_owner(token: str, message: str) -> None:
-    """Send a DM to the bot owner via Discord REST API."""
     app = _discord_api(token, "GET", "/oauth2/applications/@me")
     owner_id = app["owner"]["id"]
     channel = _discord_api(token, "POST", "/users/@me/channels", {"recipient_id": owner_id})

--- a/src/ollim_bot/updater.py
+++ b/src/ollim_bot/updater.py
@@ -28,7 +28,6 @@ class UpdateStatus:
 
 
 def _get_remote_ref(project_dir: Path) -> str:
-    """Resolve the remote tracking ref for the current branch."""
     result = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
         cwd=project_dir,
@@ -120,7 +119,6 @@ def apply_update(project_dir: Path) -> None:
 
 
 def format_error(exc: subprocess.CalledProcessError | subprocess.TimeoutExpired) -> str:
-    """Human-readable error message for a failed subprocess call."""
     cmd = shlex.join(exc.cmd) if isinstance(exc.cmd, list) else exc.cmd
     if isinstance(exc, subprocess.TimeoutExpired):
         return f"`{cmd}` timed out after {exc.timeout}s"
@@ -133,7 +131,6 @@ def format_error(exc: subprocess.CalledProcessError | subprocess.TimeoutExpired)
 
 
 def format_commit_summary(commit_summary: str, *, max_lines: int = 5) -> str:
-    """Truncate a multi-line commit log for display."""
     lines = commit_summary.splitlines()
     summary = "\n".join(lines[:max_lines])
     if len(lines) > max_lines:
@@ -142,7 +139,6 @@ def format_commit_summary(commit_summary: str, *, max_lines: int = 5) -> str:
 
 
 def log_and_restart() -> None:
-    """Log a restarting event (if session exists) and replace the process."""
     from ollim_bot.sessions import load_session_id, log_session_event
 
     session_id = load_session_id()

--- a/src/ollim_bot/webhook.py
+++ b/src/ollim_bot/webhook.py
@@ -43,12 +43,10 @@ class WebhookSpec:
 
 
 def list_webhooks() -> list[WebhookSpec]:
-    """Read all webhook spec files from the webhooks directory."""
     return read_md_dir(WEBHOOKS_DIR, WebhookSpec)
 
 
 def load_webhook(slug: str) -> WebhookSpec | None:
-    """Load a single webhook spec by its id."""
     for spec in list_webhooks():
         if spec.id == slug:
             return spec
@@ -69,7 +67,6 @@ def _inject_default_max_length(schema: dict[str, Any]) -> dict[str, Any]:
 
 
 def validate_payload(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
-    """Validate data against JSON Schema. Returns list of error messages."""
     properties = schema.get("properties", {})
     if len(properties) > _MAX_PROPERTIES:
         return [f"Too many properties ({len(properties)}, max {_MAX_PROPERTIES})"]
@@ -86,7 +83,6 @@ def build_webhook_prompt(
     skill_name: str,
     busy: bool = False,
 ) -> str:
-    """Build skill-invocation prompt with JSON payload as arguments."""
     from ollim_bot.fork_state import BgForkConfig
     from ollim_bot.scheduling.preamble import (
         build_bg_preamble,
@@ -121,7 +117,6 @@ def extract_string_fields(spec: WebhookSpec, data: dict[str, Any]) -> dict[str, 
 
 
 def build_screening_prompt(string_fields: dict[str, str]) -> str:
-    """Build the Haiku screening prompt for prompt injection detection."""
     field_lines = "\n".join(f'- {k}: "{v}"' for k, v in string_fields.items())
     return (
         "You are a prompt injection detector. Examine each field value below.\n"
@@ -199,7 +194,6 @@ async def _default_process(
 
 
 async def _screen_with_haiku(agent: Agent, string_fields: dict[str, str]) -> list[str]:
-    """Screen string field values for prompt injection via Haiku."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
     prompt = build_screening_prompt(string_fields)
@@ -269,7 +263,6 @@ def create_app(
     owner: discord.User | None = None,
     process_fn: Callable | None = None,
 ) -> web.Application:
-    """Create aiohttp application for webhook handling."""
     app = web.Application(client_max_size=_MAX_PAYLOAD_SIZE)
     app[_KEY_SECRET] = secret
     app[_KEY_AGENT] = agent
@@ -308,7 +301,6 @@ async def start(agent: Agent, owner: discord.User) -> None:
 
 
 async def stop() -> None:
-    """Graceful shutdown of webhook server."""
     global _runner
     if _runner:
         await _runner.cleanup()


### PR DESCRIPTION
## Summary
- Remove docstrings that merely restate the function name/signature from `main.py`, `doctor.py`, `updater.py`, and `webhook.py`
- Trim `_ensure_sdk_layout` docstring to first line only (remove implementation bullet list)
- Rewrite `main.py` module docstring to match CLAUDE.md convention: `"""CLI entry point and command router."""`

## Test plan
- [x] All 701 tests pass (`uv run pytest`)
- [x] Ruff lint and format checks pass
- [x] Type checks pass (ty)
- No behavioral changes — docstring-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)