### PR TITLE
fix: handle corrupt JSONL in session_start_time

### DIFF
--- a/src/ollim_bot/sessions.py
+++ b/src/ollim_bot/sessions.py
@@ -1,6 +1,7 @@
 """Persist Agent SDK session ID so conversations survive bot restarts."""
 
 import json
+import logging
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -9,6 +10,8 @@ from typing import Literal, NamedTuple, TypedDict
 
 from ollim_bot.config import TZ as _TZ
 from ollim_bot.storage import STATE_DIR, append_jsonl, atomic_write, safe_json_load
+
+log = logging.getLogger(__name__)
 
 SESSIONS_FILE = STATE_DIR / "sessions.json"
 HISTORY_FILE = STATE_DIR / "session_history.jsonl"
@@ -57,7 +60,11 @@ def session_start_time() -> datetime | None:
     for line in HISTORY_FILE.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
-        entry = json.loads(line)
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            log.warning("Skipping corrupt line in session history: %s", line)
+            continue
         if entry.get("event") == "created":
             last_created = entry["timestamp"]
     if last_created is None:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,6 +12,7 @@ from ollim_bot.sessions import (
     log_session_event,
     lookup_fork_session,
     save_session_id,
+    session_start_time,
     set_swap_in_progress,
     start_message_collector,
     track_message,
@@ -62,6 +63,27 @@ def test_log_session_event_appends(history):
 
     lines = history.read_text().strip().splitlines()
     assert len(lines) == 2
+
+
+# --- session_start_time corrupt JSONL ---
+
+
+def test_session_start_time_skips_corrupt_lines(history):
+    valid = json.dumps(
+        {"session_id": "abc", "event": "created", "timestamp": "2026-01-01T00:00:00+00:00", "parent_session_id": None}
+    )
+    history.write_text(f"{{corrupt\n{valid}\n")
+
+    result = session_start_time()
+
+    assert result is not None
+    assert result.year == 2026
+
+
+def test_session_start_time_all_corrupt(history):
+    history.write_text("{{corrupt\nnot json\n")
+
+    assert session_start_time() is None
 
 
 # --- save_session_id auto-detection ---


### PR DESCRIPTION
## Summary
- `session_start_time()` crashed with `json.JSONDecodeError` if `session_history.jsonl` contained a corrupt line
- Added `try/except json.JSONDecodeError` to skip corrupt lines with a warning log
- Added two tests: one verifying corrupt lines are skipped while valid lines are still read, one verifying all-corrupt files return `None`

## Test plan
- [x] `uv run pytest tests/test_sessions.py` — 18 tests pass
- [x] Pre-commit hooks (ruff, ruff-format, ty) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)