### PR TITLE
fix: avoid blocking event loop in follow_up_chain

### DIFF
--- a/src/ollim_bot/agent_tools.py
+++ b/src/ollim_bot/agent_tools.py
@@ -1,5 +1,6 @@
 """MCP tool definitions for agent interactions (embeds, buttons, chains, forks)."""
 
+import asyncio
 import subprocess
 import sys
 from contextvars import ContextVar
@@ -297,7 +298,7 @@ async def follow_up_chain(args: dict[str, Any]) -> dict[str, Any]:
         cmd.extend(["--allowed-tools", *ctx.allowed_tools])
     if ctx.skills:
         cmd.extend(["--skills", *ctx.skills])
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = await asyncio.to_thread(subprocess.run, cmd, capture_output=True, text=True)
     if result.returncode != 0:
         return _resp(f"Error scheduling follow-up: {result.stderr}")
     return _resp(f"Follow-up scheduled in {minutes} minutes")


### PR DESCRIPTION
## Summary
- `follow_up_chain()` called `subprocess.run()` synchronously inside an async function, blocking the entire event loop while the CLI subprocess executed
- Replaced with `await asyncio.to_thread(subprocess.run, ...)` to offload the blocking call to a thread, matching the existing pattern in `hooks.py` and `views.py`

## Test plan
- [x] All 60 existing `test_agent_tools.py` tests pass
- [x] Pre-commit hooks (ruff lint, ruff format, ty) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)