### PR TITLE
fix: fallback to defaults for invalid embed color/style

### DIFF
--- a/src/ollim_bot/embeds.py
+++ b/src/ollim_bot/embeds.py
@@ -126,7 +126,7 @@ def _unescape_newlines(text: str | None) -> str | None:
 
 def build_embed(config: EmbedConfig) -> discord.Embed:
     """Strips emoji from the title to keep Discord embed headings clean."""
-    color = COLOR_MAP[config.color]
+    color = COLOR_MAP.get(config.color, discord.Color.blue())
     title = _EMOJI_RE.sub("", config.title).strip() if config.title else None
     embed = discord.Embed(
         title=title,
@@ -152,7 +152,7 @@ def build_view(buttons: tuple[ButtonConfig, ...]) -> View | None:
     view = View(timeout=None)
     for btn in buttons[:25]:
         action = btn.action
-        style = STYLE_MAP[btn.style]
+        style = STYLE_MAP.get(btn.style, discord.ButtonStyle.secondary)
 
         # Persist prompt so the button survives bot restarts
         if action.startswith("agent:"):

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -4,7 +4,14 @@ import asyncio
 
 import discord
 
-from ollim_bot.embeds import fork_enter_embed, fork_enter_view
+from ollim_bot.embeds import (
+    ButtonConfig,
+    EmbedConfig,
+    build_embed,
+    build_view,
+    fork_enter_embed,
+    fork_enter_view,
+)
 from ollim_bot.prompts import fork_bg_resume_prompt
 
 
@@ -86,6 +93,27 @@ def test_fork_resume_notice_includes_age():
     assert "2d ago" in result
     assert "save_context" in result
     assert "report_updates" in result
+
+
+def test_build_embed_invalid_color_falls_back_to_blue():
+    config = EmbedConfig(title="Test", color="magenta")  # type: ignore[arg-type]
+
+    embed = build_embed(config)
+
+    assert embed.color == discord.Color.blue()
+
+
+def test_build_view_invalid_style_falls_back_to_secondary():
+    buttons = (ButtonConfig(label="Go", action="do_thing", style="link"),)  # type: ignore[arg-type]
+
+    async def _go():
+        return build_view(buttons)
+
+    view = _run(_go())
+
+    assert view is not None
+    btn = view.children[0]
+    assert btn.style == discord.ButtonStyle.secondary
 
 
 def test_fork_resume_notice_no_ts():


### PR DESCRIPTION
## Summary
- `COLOR_MAP[config.color]` and `STYLE_MAP[btn.style]` in `embeds.py` raised `KeyError` when the Claude agent generated values outside the `Literal` type annotations (not enforced at runtime)
- Replaced with `.get()` calls that fall back to `discord.Color.blue()` and `discord.ButtonStyle.secondary` respectively
- Added two tests verifying the fallback behavior

## Test plan
- [x] Unit tests for invalid color fallback (`test_build_embed_invalid_color_falls_back_to_blue`)
- [x] Unit tests for invalid style fallback (`test_build_view_invalid_style_falls_back_to_secondary`)
- [x] Full test suite passes (705 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)