### PR TITLE
fix: storage.py serialization/parsing bugs (4, 5, 10)

### DIFF
--- a/src/ollim_bot/storage.py
+++ b/src/ollim_bot/storage.py
@@ -127,6 +127,10 @@ def _slugify(text: str, max_len: int = 50) -> str:
     return slug
 
 
+def _yaml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _serialize_md(item: T) -> str:
     """Build YAML frontmatter + markdown body from a dataclass with a `message` field."""
     data = asdict(item)  # type: ignore[call-overload]
@@ -147,13 +151,16 @@ def _serialize_md(item: T) -> str:
             continue
         yaml_key = key.replace("_", "-")
         if isinstance(value, str):
-            lines.append(f'{yaml_key}: "{value}"')
+            lines.append(f'{yaml_key}: "{_yaml_escape(value)}"')
         elif isinstance(value, bool):
             lines.append(f"{yaml_key}: {str(value).lower()}")
         elif isinstance(value, list):
             lines.append(f"{yaml_key}:")
             for entry in value:
-                lines.append(f'  - "{entry}"' if isinstance(entry, str) else f"  - {entry}")
+                if isinstance(entry, str):
+                    lines.append(f'  - "{_yaml_escape(entry)}"')
+                else:
+                    lines.append(f"  - {entry}")
         else:
             lines.append(f"{yaml_key}: {value}")
     lines.append("---")
@@ -179,7 +186,7 @@ def parse_md(text: str, cls: type[T]) -> T:
         if key not in fields:
             continue
         expected = fields[key].type
-        if expected == "str" or expected == "str | None":
+        if expected is str or expected == (str | None):
             filtered[key] = str(value) if value is not None else None
         else:
             filtered[key] = value
@@ -249,7 +256,11 @@ def read_jsonl(filepath: Path, cls: type[T]) -> list[T]:
         stripped = line.strip()
         if not stripped or not stripped.startswith("{"):
             continue
-        data = json.loads(stripped)
+        try:
+            data = json.loads(stripped)
+        except json.JSONDecodeError:
+            log.warning("Skipping corrupt JSONL line in %s", filepath)
+            continue
         result.append(cls(**{k: v for k, v in data.items() if k in fields}))
     return result
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -324,3 +324,55 @@ def test_parse_md_accepts_legacy_snake_case_keys():
 
     assert item.allowed_tools == ["Bash(ollim-bot help)"]
     assert item.allow_ping is False
+
+
+# --- Bug 4: YAML string escaping ---
+
+
+def test_serialize_md_escapes_quotes_in_strings():
+    item = MdItem(id="abc", message="test", tag='say "hello"')
+
+    output = _serialize_md(item)
+    parsed = parse_md(output, MdItem)
+
+    assert parsed.tag == 'say "hello"'
+
+
+def test_serialize_md_escapes_quotes_in_list_entries(tmp_path):
+    item = MdItemWithList(
+        id="abc",
+        message="test",
+        tags=['value with "quotes"', "normal"],
+    )
+
+    output = _serialize_md(item)
+    parsed = parse_md(output, MdItemWithList)
+
+    assert parsed.tags == ['value with "quotes"', "normal"]
+
+
+# --- Bug 5: parse_md str coercion ---
+
+
+def test_parse_md_coerces_int_to_str():
+    """YAML parses bare 123 as int; parse_md should coerce to str for str fields."""
+    text = "---\nid: 123\n---\nhello"
+
+    item = parse_md(text, MdItem)
+
+    assert item.id == "123"
+    assert isinstance(item.id, str)
+
+
+# --- Bug 10: read_jsonl skips corrupt lines ---
+
+
+def test_read_jsonl_skips_corrupt_lines(tmp_path):
+    filepath = tmp_path / "items.jsonl"
+    filepath.write_text('{"id": "a", "name": "x", "count": 0}\nnot valid json\n{"id": "b", "name": "y", "count": 1}\n')
+
+    result = read_jsonl(filepath, Item)
+
+    assert len(result) == 2
+    assert result[0].id == "a"
+    assert result[1].id == "b"


### PR DESCRIPTION
## Summary
- **Bug 4**: `_serialize_md` now escapes `\` and `"` in YAML string values (both scalar and list entries), preventing YAML corruption. Extracted shared `_yaml_escape()` helper.
- **Bug 5**: `parse_md` compares field types against actual type objects (`str`, `str | None`) instead of string literals, so str coercion now works correctly.
- **Bug 10**: `read_jsonl` catches `json.JSONDecodeError` and logs a warning, matching its docstring promise to skip corrupt lines.

## Test plan
- [x] Added `test_serialize_md_escapes_quotes_in_strings` — roundtrip with quotes in string field
- [x] Added `test_serialize_md_escapes_quotes_in_list_entries` — roundtrip with quotes in list entries
- [x] Added `test_parse_md_coerces_int_to_str` — YAML bare int coerced to str for str fields
- [x] Added `test_read_jsonl_skips_corrupt_lines` — corrupt JSON line skipped, valid lines parsed
- [x] All 32 storage tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)