### PR TITLE
fix: handle str stderr in format_error

### DIFF
--- a/src/ollim_bot/updater.py
+++ b/src/ollim_bot/updater.py
@@ -124,7 +124,8 @@ def format_error(exc: subprocess.CalledProcessError | subprocess.TimeoutExpired)
         return f"`{cmd}` timed out after {exc.timeout}s"
     msg = f"`{cmd}` returned {exc.returncode}"
     if exc.stderr:
-        stderr = exc.stderr.decode(errors="replace").strip()
+        stderr = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode(errors="replace")
+        stderr = stderr.strip()
         if stderr:
             msg += f"\n```\n{stderr}\n```"
     return msg

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from ollim_bot.updater import apply_update
+from ollim_bot.updater import apply_update, format_error
 
 
 def test_apply_update_runs_all_commands(tmp_path: Path) -> None:
@@ -61,3 +61,33 @@ def test_apply_update_aborts_on_upgrade_failure(tmp_path: Path) -> None:
         ["git", "pull", "--ff-only"],
         ["uv", "tool", "upgrade", "ollim-bot"],
     ]
+
+
+def test_format_error_with_str_stderr() -> None:
+    """format_error handles str stderr (from text=True subprocess calls)."""
+    exc = subprocess.CalledProcessError(1, ["git", "pull", "--ff-only"], stderr="fatal: not a git repo\n")
+    result = format_error(exc)
+    assert "`git pull --ff-only` returned 1" in result
+    assert "fatal: not a git repo" in result
+
+
+def test_format_error_with_bytes_stderr() -> None:
+    """format_error handles bytes stderr (from capture_output without text=True)."""
+    exc = subprocess.CalledProcessError(1, ["git", "pull", "--ff-only"], stderr=b"fatal: not a git repo\n")
+    result = format_error(exc)
+    assert "`git pull --ff-only` returned 1" in result
+    assert "fatal: not a git repo" in result
+
+
+def test_format_error_without_stderr() -> None:
+    """format_error works when stderr is None."""
+    exc = subprocess.CalledProcessError(1, ["git", "pull", "--ff-only"])
+    result = format_error(exc)
+    assert result == "`git pull --ff-only` returned 1"
+
+
+def test_format_error_timeout() -> None:
+    """format_error handles TimeoutExpired."""
+    exc = subprocess.TimeoutExpired(["git", "fetch", "origin"], timeout=60)
+    result = format_error(exc)
+    assert result == "`git fetch origin` timed out after 60s"


### PR DESCRIPTION
## Summary
- `format_error()` in `updater.py` called `.decode()` on `exc.stderr` unconditionally, but `apply_update()` uses `text=True` in some subprocess calls, making `stderr` a `str` — calling `.decode()` on a `str` raises `AttributeError`
- Added `isinstance` check to handle both `str` and `bytes` stderr
- Added 4 tests covering str stderr, bytes stderr, None stderr, and TimeoutExpired

## Test plan
- [x] `test_format_error_with_str_stderr` — verifies str stderr works
- [x] `test_format_error_with_bytes_stderr` — verifies bytes stderr works
- [x] `test_format_error_without_stderr` — verifies None stderr works
- [x] `test_format_error_timeout` — verifies TimeoutExpired formatting
- [x] Full test suite passes (707 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)