### PR TITLE
fix: handle IndexError from malformed cron in scheduler

### DIFF
--- a/src/ollim_bot/doctor.py
+++ b/src/ollim_bot/doctor.py
@@ -68,7 +68,7 @@ def _count_md_files(directory: Path) -> int:
 
 
 def check_routines() -> list[CheckResult]:
-    from ollim_bot.scheduling.preamble import _routine_next_fire
+    from ollim_bot.scheduling.preamble import _convert_dow, _routine_next_fire
     from ollim_bot.scheduling.routines import ROUTINES_DIR
 
     results: list[CheckResult] = []
@@ -91,20 +91,33 @@ def check_routines() -> list[CheckResult]:
 
     now = datetime.now(TZ)
     for routine in routines:
-        try:
-            nxt = _routine_next_fire(routine, now)
-        except (ValueError, KeyError) as exc:
-            results.append(
-                CheckResult(
-                    "FAIL",
-                    routine.id,
-                    f"invalid cron '{routine.cron}': {exc}",
-                )
-            )
-            continue
+        nxt = _routine_next_fire(routine, now)
 
         if nxt is None:
-            results.append(CheckResult("WARN", routine.id, f"no upcoming fire time (cron: {routine.cron})"))
+            # Distinguish malformed cron from legitimately no upcoming fire
+            parts = routine.cron.split()
+            if len(parts) != 5:
+                results.append(
+                    CheckResult(
+                        "FAIL", routine.id, f"invalid cron '{routine.cron}': expected 5 fields, got {len(parts)}"
+                    )
+                )
+            else:
+                # Try constructing CronTrigger to surface the actual error
+                from apscheduler.triggers.cron import CronTrigger
+
+                try:
+                    CronTrigger(
+                        minute=parts[0],
+                        hour=parts[1],
+                        day=parts[2],
+                        month=parts[3],
+                        day_of_week=_convert_dow(parts[4]),
+                        timezone=str(TZ),
+                    )
+                    results.append(CheckResult("WARN", routine.id, f"no upcoming fire time (cron: {routine.cron})"))
+                except (ValueError, KeyError, IndexError) as exc:
+                    results.append(CheckResult("FAIL", routine.id, f"invalid cron '{routine.cron}': {exc}"))
         else:
             local_time = nxt.strftime("%I:%M %p").lstrip("0")
             delta = nxt - now

--- a/src/ollim_bot/scheduling/preamble.py
+++ b/src/ollim_bot/scheduling/preamble.py
@@ -71,14 +71,17 @@ _TRUNCATE_LEN = 60
 
 def _routine_next_fire(routine: Routine, after: datetime) -> datetime | None:
     parts = routine.cron.split()
-    trigger = CronTrigger(
-        minute=parts[0],
-        hour=parts[1],
-        day=parts[2],
-        month=parts[3],
-        day_of_week=_convert_dow(parts[4]),
-        timezone=str(TZ),
-    )
+    try:
+        trigger = CronTrigger(
+            minute=parts[0],
+            hour=parts[1],
+            day=parts[2],
+            month=parts[3],
+            day_of_week=_convert_dow(parts[4]),
+            timezone=str(TZ),
+        )
+    except (ValueError, KeyError, IndexError):
+        return None
     return trigger.get_next_fire_time(None, after)
 
 

--- a/src/ollim_bot/scheduling/scheduler.py
+++ b/src/ollim_bot/scheduling/scheduler.py
@@ -185,7 +185,7 @@ def _register_routine(
             ),
             id=f"routine_{routine.id}",
         )
-    except (ValueError, KeyError):
+    except (ValueError, KeyError, IndexError):
         log.exception("Failed to register routine %s (cron: %s)", routine.id, routine.cron)
         problem_key = f"routine_reg_{routine.id}"
         if problem_key not in _reported_problems:

--- a/tests/test_scheduler_prompts.py
+++ b/tests/test_scheduler_prompts.py
@@ -7,6 +7,7 @@ from ollim_bot.fork_state import BgForkConfig
 from ollim_bot.scheduling.preamble import (
     ScheduleEntry,
     _convert_dow,
+    _routine_next_fire,
     build_bg_preamble,
     build_reminder_prompt,
     build_routine_prompt,
@@ -561,3 +562,29 @@ def test_reminder_prompt_no_overdue_no_late_notice():
     prompt = build_reminder_prompt(reminder, skill_name="reminder-r1", reminders=[], routines=[])
 
     assert "[late:" not in prompt
+
+
+# --- Malformed cron handling ---
+
+
+def test_routine_next_fire_short_cron_returns_none():
+    """Cron with fewer than 5 fields should return None, not raise IndexError."""
+    routine = Routine(id="bad", message="Broken", cron="* * *")
+    result = _routine_next_fire(routine, datetime.now(TZ))
+    assert result is None
+
+
+def test_schedule_skips_routine_with_short_cron(monkeypatch):
+    """build_upcoming_schedule gracefully skips routines with malformed cron."""
+    fixed_now = datetime.now(TZ).replace(hour=10, minute=0, second=0, microsecond=0)
+    _patch_now(monkeypatch, fixed_now)
+    routines = [
+        Routine(id="bad", message="Broken", cron="* * *", background=True),
+        Routine(id="good", message="OK", cron="0 12 * * *", background=True),
+    ]
+
+    entries = build_upcoming_schedule(routines, [], current_id="other")
+
+    ids = [e.id for e in entries]
+    assert "bad" not in ids
+    assert "good" in ids


### PR DESCRIPTION
## Summary
- Cron strings with fewer than 5 fields (e.g. `"* * *"`) caused `IndexError` on `parts[4]`, which was not caught by the `(ValueError, KeyError)` except clause in `scheduler.py`, crashing `sync_all()` every 10 seconds
- Added `IndexError` to the except clause in `scheduler.py:_register_routine`
- Wrapped `CronTrigger` construction in `preamble.py:_routine_next_fire` with `try/except (ValueError, KeyError, IndexError)`, returning `None` on failure
- Updated `doctor.py:check_routines` to distinguish invalid cron (FAIL) from no upcoming fire (WARN) after `_routine_next_fire` now returns `None` instead of raising

## Test plan
- [x] New test: `test_routine_next_fire_short_cron_returns_none` — verifies 3-field cron returns `None`
- [x] New test: `test_schedule_skips_routine_with_short_cron` — verifies `build_upcoming_schedule` skips bad cron
- [x] Existing test: `test_check_routines_detects_invalid_cron` — still passes with updated doctor logic
- [x] Full suite: 705 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)