### PR TITLE
fix: forward model= to create_forked_client in non-isolated bg forks

### DIFF
--- a/src/ollim_bot/forks.py
+++ b/src/ollim_bot/forks.py
@@ -203,6 +203,7 @@ async def run_agent_background(
                         )
                     else:
                         client = await agent.create_forked_client(
+                            model=model,
                             thinking=thinking,
                             allowed_tools=allowed,
                             bg=True,

--- a/tests/test_forks.py
+++ b/tests/test_forks.py
@@ -780,3 +780,29 @@ def test_bg_tracking_mutations():
     assert t2.reported is True
     assert t2.output_sent is True
     assert t2.ping_count == 1
+
+
+def test_model_forwarded_to_forked_client(data_dir, monkeypatch):
+    """model= must be forwarded to create_forked_client (non-isolated path)."""
+    from ollim_bot import runtime_config
+    from ollim_bot.channel import init_channel
+    from ollim_bot.runtime_config import RuntimeConfig
+
+    channel = AsyncMock()
+    channel.send = AsyncMock()
+    init_channel(channel)
+
+    agent = AsyncMock()
+    agent.lock = MagicMock(return_value=asyncio.Lock())
+
+    client = AsyncMock()
+    agent.create_forked_client = AsyncMock(return_value=client)
+    agent.run_on_client = AsyncMock(return_value="fork-session-id")
+
+    monkeypatch.setattr(runtime_config, "load", lambda: RuntimeConfig())
+
+    _run(run_agent_background(agent, "[routine-bg:test] do stuff", model="haiku"))
+
+    agent.create_forked_client.assert_awaited_once()
+    call_kwargs = agent.create_forked_client.call_args.kwargs
+    assert call_kwargs["model"] == "haiku"


### PR DESCRIPTION
## Summary
- Non-isolated bg forks in `run_agent_background()` were not passing `model=model` to `create_forked_client()`, causing the specified model to be silently ignored
- Added the missing `model=model` kwarg to match the isolated path which already forwarded it correctly
- Added a test verifying model is forwarded to `create_forked_client`

## Test plan
- [x] New unit test `test_model_forwarded_to_forked_client` asserts model kwarg is passed
- [x] All 704 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)