### PR TITLE
fix: wrap sync git calls in asyncio.to_thread

### DIFF
--- a/src/ollim_bot/agent.py
+++ b/src/ollim_bot/agent.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import replace
 
 from claude_agent_sdk import (
@@ -154,7 +154,7 @@ class Agent:
             await self.exit_interactive_fork(ForkExitAction.EXIT)
         current = load_session_id()
         if current:
-            log_session_event(current, "cleared")
+            await asyncio.to_thread(log_session_event, current, "cleared")
         await self._drop_client()
         delete_session_id()
 
@@ -243,10 +243,10 @@ class Agent:
         self._client = client
         set_swap_in_progress(True)
         try:
-            save_session_id(session_id)
+            await asyncio.to_thread(save_session_id, session_id)
         finally:
             set_swap_in_progress(False)
-        log_session_event(session_id, "swapped", parent_session_id=old_session_id)
+        await asyncio.to_thread(log_session_event, session_id, "swapped", parent_session_id=old_session_id)
         if old:
             with contextlib.suppress(CLIConnectionError):
                 await old.interrupt()
@@ -408,7 +408,7 @@ class Agent:
             elif isinstance(msg, ResultMessage):
                 result_msg = msg
                 if self._client is client:
-                    save_session_id(msg.session_id)
+                    await asyncio.to_thread(save_session_id, msg.session_id)
 
         return format_compact_stats(result_msg, pre_tokens)
 
@@ -431,7 +431,7 @@ class Agent:
                 if msg.result:
                     parts.append(msg.result)
                 if self._client is client:
-                    save_session_id(msg.session_id)
+                    await asyncio.to_thread(save_session_id, msg.session_id)
 
         return parts, result_msg
 
@@ -457,20 +457,20 @@ class Agent:
         client = await self._get_client()
         return client, message
 
-    def _try_capture_fork_session(self, session_id: str) -> None:
+    async def _try_capture_fork_session(self, session_id: str) -> None:
         """Idempotent -- first call wins."""
         if self._fork_session_id is not None:
             return
         self._fork_session_id = session_id
-        log_session_event(session_id, "interactive_fork", parent_session_id=load_session_id())
+        await asyncio.to_thread(log_session_event, session_id, "interactive_fork", parent_session_id=load_session_id())
 
-    def _save_result_session(self, client: ClaudeSDKClient, msg: ResultMessage) -> None:
+    async def _save_result_session(self, client: ClaudeSDKClient, msg: ResultMessage) -> None:
         if self._fork_client is not None and client is self._fork_client:
-            self._try_capture_fork_session(msg.session_id)
+            await self._try_capture_fork_session(msg.session_id)
         elif self._client is client:
-            save_session_id(msg.session_id)
+            await asyncio.to_thread(save_session_id, msg.session_id)
 
-    def _capture_fork_session(self, client: ClaudeSDKClient) -> Callable[[str], None] | None:
+    def _capture_fork_session(self, client: ClaudeSDKClient) -> Callable[[str], Awaitable[None]] | None:
         if self._fork_client is None or client is not self._fork_client:
             return None
         return self._try_capture_fork_session

--- a/src/ollim_bot/agent_streaming.py
+++ b/src/ollim_bot/agent_streaming.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 
 from claude_agent_sdk import (
     AssistantMessage,
@@ -62,8 +62,8 @@ async def stream_response(
     message: str,
     *,
     images: list[dict[str, str]] | None = None,
-    on_fork_session: Callable[[str], None] | None = None,
-    on_result_session: Callable[[ClaudeSDKClient, ResultMessage], None] | None = None,
+    on_fork_session: Callable[[str], None | Awaitable[None]] | None = None,
+    on_result_session: Callable[[ClaudeSDKClient, ResultMessage], None | Awaitable[None]] | None = None,
 ) -> AsyncGenerator[str | StreamStatus, None]:
     """Stream a single agent response, yielding text deltas and status signals.
 
@@ -127,7 +127,9 @@ async def stream_response(
 
                     if on_fork_session is not None and not fork_session_notified:
                         fork_session_notified = True
-                        on_fork_session(msg.session_id)
+                        result = on_fork_session(msg.session_id)
+                        if result is not None:
+                            await result
 
                     async for item in parser.feed(msg.event):
                         streamed = True
@@ -143,7 +145,9 @@ async def stream_response(
                     if msg.result:
                         result_text = msg.result
                     if on_result_session is not None:
-                        on_result_session(client, msg)
+                        result = on_result_session(client, msg)
+                        if result is not None:
+                            await result
         except CLIConnectionError:
             if not fork_interrupted:
                 raise

--- a/src/ollim_bot/forks.py
+++ b/src/ollim_bot/forks.py
@@ -226,7 +226,8 @@ async def run_agent_background(
             assert client is not None
             try:
                 fork_session_id = await agent.run_on_client(client, prompt, prepend_updates=not isolated)
-                log_session_event(
+                await asyncio.to_thread(
+                    log_session_event,
                     fork_session_id,
                     "isolated_bg" if isolated else "bg_fork",
                     parent_session_id=None if isolated else main_session_id,

--- a/src/ollim_bot/reminder_tools.py
+++ b/src/ollim_bot/reminder_tools.py
@@ -1,5 +1,6 @@
 """MCP tool definitions for reminder management (add, list, cancel)."""
 
+import asyncio
 from datetime import datetime
 from typing import Any
 
@@ -92,7 +93,7 @@ async def add_reminder(args: dict[str, Any]) -> dict[str, Any]:
         description=args.get("description", ""),
         max_chain=args.get("max_chain", 0),
     )
-    append_reminder(reminder)
+    await asyncio.to_thread(append_reminder, reminder)
 
     fire_dt = datetime.fromisoformat(reminder.run_at)
     fire_str = fire_dt.strftime("%I:%M %p").lstrip("0")
@@ -135,6 +136,7 @@ async def list_reminders_tool(args: dict[str, Any]) -> dict[str, Any]:
 )
 async def cancel_reminder(args: dict[str, Any]) -> dict[str, Any]:
     reminder_id = args["reminder_id"]
-    if remove_reminder(reminder_id):
+    removed = await asyncio.to_thread(remove_reminder, reminder_id)
+    if removed:
         return _resp(f"Reminder {reminder_id} cancelled.")
     return _resp(f"Error: no reminder found with ID {reminder_id}.")

--- a/src/ollim_bot/scheduling/scheduler.py
+++ b/src/ollim_bot/scheduling/scheduler.py
@@ -273,7 +273,7 @@ def _register_reminder(
             raise
         finally:
             set_chain_context(None)
-            remove_reminder(reminder.id)
+            await asyncio.to_thread(remove_reminder, reminder.id)
             _registered_reminders.discard(reminder.id)
 
     run_at = datetime.fromisoformat(reminder.run_at)

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -105,13 +105,13 @@ class TestProperties:
 class TestSessionCapture:
     def test_try_capture_first_call_sets(self, agent):
         with patch("ollim_bot.agent.log_session_event"), patch("ollim_bot.agent.load_session_id", return_value=None):
-            agent._try_capture_fork_session("fork-1")
+            _run(agent._try_capture_fork_session("fork-1"))
         assert agent._fork_session_id == "fork-1"
 
     def test_try_capture_idempotent(self, agent):
         with patch("ollim_bot.agent.log_session_event"), patch("ollim_bot.agent.load_session_id", return_value=None):
-            agent._try_capture_fork_session("fork-1")
-            agent._try_capture_fork_session("fork-2")
+            _run(agent._try_capture_fork_session("fork-1"))
+            _run(agent._try_capture_fork_session("fork-2"))
         assert agent._fork_session_id == "fork-1"
 
     def test_capture_fork_session_returns_callback_for_fork_client(self, agent):


### PR DESCRIPTION
## Summary
- Wrapped all `storage.git_commit()` / `git_rm_commit()` calls from async code in `await asyncio.to_thread()` to avoid blocking the event loop with `subprocess.run()`
- Updated `agent_streaming.py` callbacks to support both sync and async callables, enabling `_save_result_session` and `_try_capture_fork_session` to become async
- Applied the fix across 5 source files: `reminder_tools.py`, `agent.py`, `forks.py`, `scheduler.py`, `agent_streaming.py`

## Test plan
- [x] All 703 existing tests pass
- [x] `test_reminder_tools.py` — add/cancel reminder tools work with `to_thread` wrapping
- [x] `test_sessions.py` — session event logging unchanged (sync functions not modified)
- [x] `test_agent_state.py` — updated to await async `_try_capture_fork_session`
- [x] Pre-commit hooks pass (ruff, ruff-format, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)